### PR TITLE
Fix cors config key

### DIFF
--- a/app/utils/config/cors.py
+++ b/app/utils/config/cors.py
@@ -24,7 +24,7 @@ class CorsConfig:
         if environment == "test_environment":
             return cls.CORS_DEFAULT
 
-        cors_config = configs.get("cors", {})
+        cors_config = configs.get("cors") or configs.get("cor_origins") or {}
         if cors_config:
             allowed = cors_config.get("allowed", cls.CORS_DEFAULT["allowed"])
             blocked = cors_config.get("blocked", cls.CORS_DEFAULT["blocked"])

--- a/tests/utils/config/test_cors.py
+++ b/tests/utils/config/test_cors.py
@@ -42,6 +42,20 @@ class TestCorsConfig(unittest.TestCase):
         result = CorsConfig.get_cors(config, environment="staging")
         self.assertEqual(result, CorsConfig.CORS_DEFAULT)
 
+    def test_cor_origins_key_supported(self):
+        config = {
+            "cor_origins": {
+                "allowed": ["https://example.org"],
+                "blocked": ["http://bad.example.org"],
+            }
+        }
+        result = CorsConfig.get_cors(config, environment="production")
+        expected = {
+            "allowed": ["https://example.org"],
+            "blocked": ["http://bad.example.org"],
+        }
+        self.assertEqual(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `CorsConfig.get_cors` to recognize both `cors` and `cor_origins`
- add regression test for `cor_origins` key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683ffb839c58832a9ecb411e7dd08333