### PR TITLE
Test coverage

### DIFF
--- a/app/database/base_model.py
+++ b/app/database/base_model.py
@@ -203,16 +203,16 @@ class BaseModel(Base):
 
             json_field = getattr(record, column_name)
 
-            # MutableDict takes care of tracking, no need to reassign:
             if json_field is None:
-                json_field = {}
-                setattr(record, column_name, json_field)
+                setattr(record, column_name, {})
+                json_field = getattr(record, column_name)
 
             if not isinstance(json_field, dict):
                 raise ValueError(f"Column {column_name} is not a JSON field.")
 
-            json_field[key] = value  # Automatic change tracking by MutableDict
+            json_field[key] = value
             session.commit()
+            session.refresh(record)
             logger.info(
                 f"Updated JSON field '{column_name}' for {cls.__name__} with id={record_id}"
             )
@@ -249,17 +249,17 @@ class BaseModel(Base):
             json_field = getattr(record, column_name)
 
             if json_field is None:
-                json_field = {}
-                setattr(record, column_name, json_field)
+                setattr(record, column_name, {})
+                json_field = getattr(record, column_name)
 
             if not isinstance(json_field, dict):
                 raise ValueError(f"Column '{column_name}' is not a JSON/dict field.")
 
             for key, value in updates.items():
-                json_field[key] = value  # MutableDict handles change tracking
+                json_field[key] = value
 
             session.commit()
-            session.refresh(record)  # Ensure we return fresh state after commit
+            session.refresh(record)
 
             logger.info(
                 f"Bulk updated JSON field '{column_name}' for {cls.__name__} with id={record_id}: {updates}"

--- a/app/database/session_manager.py
+++ b/app/database/session_manager.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class DatabaseSessionManager:
     def __init__(self, configs: Optional[dict | RuntimeSettings] = None) -> None:
         self._base = Base
-        self.configs = configs or get_settings()
+        self.configs = get_settings() if configs is None else configs
         if isinstance(self.configs, dict):
             self.database_url = self.configs.get(
                 "database_url", "sqlite:///./development.db"

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -147,7 +147,7 @@ def register_exception_handlers(app: FastAPI) -> None:
             },
         )
         return json_error(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             correlation_id=correlation_id,
             message="Validation failed",
             code="validation_error",

--- a/app/models/company/response_messages.py
+++ b/app/models/company/response_messages.py
@@ -34,15 +34,13 @@ class CompanyUserResponseMessages(str, Enum):
     # Add user
     ADD_USER_SUCCESS = "User has been successfully added to the company."
     ADD_USER_FAILED = "Failed to add user to the company. Please verify the input."
-    ADD_EXISTING_USER_FAILED = (
-        "This user is already associated with the specified company."
-    )
+    ADD_EXISTING_USER_FAILED = "User is already linked to company."
 
     # Remove user
     REMOVE_USER_SUCCESS = "User has been successfully removed from the company."
     REMOVE_USER_FAILED = "Failed to remove user from the company. Try again later."
     SUPER_ADMIN_REMOVE_FORBIDDEN = "You cannot remove super admin from company."
-    USER_ALREADY_REMOVED = "User is already removed from company."
+    USER_ALREADY_REMOVED = "User has already been removed from company."
 
 
 class CompanyRoleResponseMessages(str, Enum):

--- a/tests/database/test_association_extra.py
+++ b/tests/database/test_association_extra.py
@@ -1,0 +1,98 @@
+import pytest
+
+from app.database.association_user_company import AssociationUserCompany
+from app.database.company import Company
+from app.database.role import Role
+from app.database.user import User
+from app.models.user.account_status import UserAccountStatus
+from app.models.user.user import UserReadModel
+from app.utils.app_error import AppError
+
+
+def _acting_user(*, user_id: int) -> UserReadModel:
+    return UserReadModel(
+        id=user_id,
+        first_name="Admin",
+        last_name="User",
+        email="admin@example.com",
+        phone_number="1234567890",
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=True,
+    )
+
+
+def test_is_user_linked_to_company_supports_role_filter(
+    test_session, test_company_data, test_user_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    user = User.create(test_session, **test_user_data["create_user"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+    AssociationUserCompany.create(
+        test_session, user_id=user["id"], company_id=company["id"], role_name=role["name"]
+    )
+
+    assert AssociationUserCompany.is_user_linked_to_company(
+        test_session, user["id"], company["id"], role["name"]
+    ) is True
+    assert AssociationUserCompany.is_user_linked_to_company(
+        test_session, user["id"], company["id"], "Viewer"
+    ) is False
+
+
+def test_link_user_rejects_duplicate_active_link(
+    test_session, test_company_data, test_user_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    user = User.create(test_session, **test_user_data["create_user"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+    acting_user = _acting_user(user_id=999)
+    AssociationUserCompany.link_user(
+        test_session, company["id"], user["id"], role["name"], acting_user
+    )
+
+    with pytest.raises(ValueError, match="User is already linked"):
+        AssociationUserCompany.link_user(
+            test_session, company["id"], user["id"], role["name"], acting_user
+        )
+
+
+def test_unlink_user_rejects_missing_link(
+    test_session, test_company_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+
+    with pytest.raises(AppError, match="User has already been removed"):
+        AssociationUserCompany.unlink_user(
+            test_session, company["id"], 1, _acting_user(user_id=999)
+        )
+
+
+def test_unlink_user_rejects_self_removal_for_administrator(
+    test_session, test_company_data, test_user_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    user = User.create(test_session, **test_user_data["create_user"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name="Administrator",
+        description=test_role_data["admin_role"]["description"],
+    )
+    AssociationUserCompany.link_user(
+        test_session, company["id"], user["id"], role["name"], _acting_user(user_id=999)
+    )
+
+    with pytest.raises(AppError, match="You cannot remove super admin from company."):
+        AssociationUserCompany.unlink_user(
+            test_session, company["id"], user["id"], _acting_user(user_id=user["id"])
+        )

--- a/tests/database/test_base_model_extra.py
+++ b/tests/database/test_base_model_extra.py
@@ -1,0 +1,146 @@
+import pytest
+
+from app.database.base_model import BaseModel, RecordNotFoundError
+from app.database.company import Company
+from app.database.user import User
+
+
+def test_to_dict_handles_none_and_model_lists(test_session, test_user_data):
+    user_one = User.create(test_session, **test_user_data["create_user"])
+    user_two = User.create(
+        test_session,
+        email="two@example.com",
+        password="secret",
+        first_name="Two",
+    )
+
+    records = test_session.query(User).order_by(User.id).all()
+
+    assert BaseModel.to_dict(None) == {}
+    assert BaseModel.to_dict(records)[0]["id"] == user_one["id"]
+    assert BaseModel.to_dict(records)[1]["id"] == user_two["id"]
+
+
+def test_to_dict_falls_back_to_convert_datetime_for_plain_values():
+    assert BaseModel.to_dict({"nested": "value"}) == {"nested": "value"}
+
+
+def test_update_missing_record_raises_record_not_found(test_session):
+    with pytest.raises(RecordNotFoundError):
+        User.update(test_session, 999, first_name="missing")
+
+
+def test_update_by_filters_missing_record_raises_value_error(test_session):
+    with pytest.raises(ValueError, match="User with filters"):
+        User.update_by_filters(test_session, filters={"email": "missing@example.com"}, first_name="missing")
+
+
+def test_delete_missing_record_raises_record_not_found(test_session):
+    with pytest.raises(RecordNotFoundError):
+        User.delete(test_session, 999)
+
+
+def test_delete_by_filters_missing_record_raises_value_error(test_session):
+    with pytest.raises(ValueError, match="User with filters"):
+        User.delete_by_filters(test_session, filters={"email": "missing@example.com"})
+
+
+def test_bulk_create_creates_multiple_companies(test_session):
+    result = Company.bulk_create(
+        test_session,
+        [
+            {"email": "bulk-one@example.com", "name": "Bulk One"},
+            {"email": "bulk-two@example.com", "name": "Bulk Two"},
+        ],
+    )
+
+    assert result == {"message": "2 records added successfully"}
+    assert test_session.query(Company).count() == 2
+
+
+def test_update_json_field_initializes_none_json_column(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+    user = test_session.query(User).filter_by(id=created["id"]).one()
+    user.primary_meta_data = None
+    test_session.commit()
+
+    updated = User.update_json_field(
+        test_session,
+        created["id"],
+        "primary_meta_data",
+        "status",
+        "Active",
+    )
+
+    assert updated["primary_meta_data"]["status"] == "Active"
+
+
+def test_update_json_field_rejects_non_dict_columns(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+
+    with pytest.raises(ValueError, match="Column email is not a JSON field."):
+        User.update_json_field(test_session, created["id"], "email", "status", "Active")
+
+
+def test_bulk_update_json_field_updates_multiple_keys(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+
+    updated = User.bulk_update_json_field(
+        test_session,
+        created["id"],
+        "primary_meta_data",
+        {"status": "Active", "source": "tests"},
+    )
+
+    assert updated["primary_meta_data"]["status"] == "Active"
+    assert updated["primary_meta_data"]["source"] == "tests"
+
+
+def test_bulk_update_json_field_initializes_none_json_column(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+    user = test_session.query(User).filter_by(id=created["id"]).one()
+    user.secondary_meta_data = None
+    test_session.commit()
+
+    updated = User.bulk_update_json_field(
+        test_session,
+        created["id"],
+        "secondary_meta_data",
+        {"source": "tests"},
+    )
+
+    assert updated["secondary_meta_data"]["source"] == "tests"
+
+
+def test_bulk_update_json_field_rejects_invalid_column(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+
+    with pytest.raises(ValueError, match="Column 'missing_column' does not exist on the model."):
+        User.bulk_update_json_field(
+            test_session,
+            created["id"],
+            "missing_column",
+            {"source": "tests"},
+        )
+
+
+def test_bulk_update_json_field_rejects_non_dict_column(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+
+    with pytest.raises(ValueError, match="Column 'email' is not a JSON/dict field."):
+        User.bulk_update_json_field(
+            test_session,
+            created["id"],
+            "email",
+            {"source": "tests"},
+        )
+
+
+def test_bulk_update_json_field_missing_record_raises_record_not_found(test_session):
+    with pytest.raises(RecordNotFoundError):
+        User.bulk_update_json_field(
+            test_session,
+            999,
+            "primary_meta_data",
+            {"source": "tests"},
+        )

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -1,0 +1,16 @@
+import pytest
+
+from app.database.company import Company
+
+
+def test_get_company_by_email_returns_company(test_session, test_company_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+
+    result = Company.get_company_by_email(test_session, company["email"])
+
+    assert result["id"] == company["id"]
+
+
+def test_get_company_by_email_raises_for_missing_company(test_session):
+    with pytest.raises(ValueError, match="Company with email:missing@example.com, not found."):
+        Company.get_company_by_email(test_session, "missing@example.com")

--- a/tests/database/test_role_extra.py
+++ b/tests/database/test_role_extra.py
@@ -1,0 +1,144 @@
+import pytest
+
+from app.database.association_user_company import AssociationUserCompany
+from app.database.company import Company
+from app.database.role import Role
+from app.database.user import User
+from app.models.user.user import UserReadModel
+from app.utils.app_error import AppError
+
+
+def _deleted_by_user() -> UserReadModel:
+    return UserReadModel(
+        id=99,
+        first_name="Admin",
+        last_name="User",
+        email="admin@example.com",
+        phone_number="1234567890",
+        status="Active",
+        is_superuser=True,
+    )
+
+
+def test_role_belongs_to_company_returns_role_dict(test_session, test_company_data, test_role_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+
+    result = Role.role_belongs_to_company(test_session, company["id"], role["name"])
+
+    assert result["name"] == role["name"]
+
+
+def test_role_belongs_to_company_raises_when_role_missing(test_session, test_company_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+
+    with pytest.raises(AppError, match="Role: Missing is not linked to the company"):
+        Role.role_belongs_to_company(test_session, company["id"], "Missing")
+
+
+def test_update_role_raises_when_role_missing(test_session):
+    with pytest.raises(ValueError, match="Role with company_id=1 and name='Missing' not found."):
+        Role.update_role(test_session, 1, "Missing", new_name="Renamed")
+
+
+def test_update_role_json_field_rejects_missing_role(test_session):
+    with pytest.raises(ValueError, match="Role with company_id=1 and name='Missing' not found."):
+        Role.update_json_field(test_session, 1, "Missing", "primary_meta_data", "key", "value")
+
+
+def test_update_role_json_field_rejects_missing_column(test_session, test_company_data, test_role_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+
+    with pytest.raises(ValueError, match="Column 'missing' does not exist on Role."):
+        Role.update_json_field(test_session, company["id"], role["name"], "missing", "key", "value")
+
+
+def test_update_role_json_field_rejects_non_dict_column(test_session, test_company_data, test_role_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+
+    with pytest.raises(ValueError, match="Column 'description' is not a JSON field."):
+        Role.update_json_field(test_session, company["id"], role["name"], "description", "key", "value")
+
+
+def test_delete_role_and_reassign_users_rejects_same_replacement_name(test_session):
+    with pytest.raises(ValueError, match="Cannot replace a role with itself."):
+        Role.delete_role_and_reassign_users(
+            test_session, 1, "Admin", "Admin", _deleted_by_user()
+        )
+
+
+def test_delete_role_and_reassign_users_rejects_missing_target_role(test_session, test_company_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+
+    with pytest.raises(ValueError, match="Role 'Admin' not found."):
+        Role.delete_role_and_reassign_users(
+            test_session, company["id"], "Admin", "Viewer", _deleted_by_user()
+        )
+
+
+def test_delete_role_and_reassign_users_rejects_missing_replacement_role(test_session, test_company_data, test_role_data):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+
+    with pytest.raises(ValueError, match="Replacement role 'Viewer' not found."):
+        Role.delete_role_and_reassign_users(
+            test_session, company["id"], "Admin", "Viewer", _deleted_by_user()
+        )
+
+
+def test_delete_role_and_reassign_users_soft_deletes_and_reassigns_users(
+    test_session, test_company_data, test_role_data, test_user_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    admin_role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["admin_role"]["name"],
+        description=test_role_data["admin_role"]["description"],
+    )
+    viewer_role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["viewer_role"]["name"],
+        description=test_role_data["viewer_role"]["description"],
+    )
+    user = User.create(test_session, **test_user_data["create_user"])
+    AssociationUserCompany.create(
+        test_session,
+        user_id=user["id"],
+        company_id=company["id"],
+        role_name=admin_role["name"],
+    )
+
+    result = Role.delete_role_and_reassign_users(
+        test_session, company["id"], admin_role["name"], viewer_role["name"], _deleted_by_user()
+    )
+
+    updated_link = test_session.query(AssociationUserCompany).one()
+    deleted_role = test_session.query(Role).filter_by(company_id=company["id"], name=admin_role["name"]).one()
+    assert result["users_reassigned"] == 1
+    assert updated_link.role_name == viewer_role["name"]
+    assert deleted_role.primary_meta_data["deleted_by"]["email"] == "admin@example.com"
+    assert deleted_role._closed_at is not None

--- a/tests/database/test_session_manager.py
+++ b/tests/database/test_session_manager.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from app.database.session_manager import DatabaseSessionManager
+
+
+def test_session_manager_uses_default_sqlite_url_for_dict_configs(monkeypatch):
+    create_engine_calls = []
+    monkeypatch.setattr("app.database.session_manager.create_engine", lambda url, **kwargs: create_engine_calls.append((url, kwargs)) or "engine")
+    monkeypatch.setattr("app.database.session_manager.Base.metadata.create_all", lambda bind: None)
+    monkeypatch.setattr("app.database.session_manager.DatabaseSessionManager._import_models", lambda self: None)
+
+    manager = DatabaseSessionManager(configs={})
+
+    assert manager.database_url == "sqlite:///./development.db"
+    assert create_engine_calls[0][1]["connect_args"] == {"check_same_thread": False}
+
+
+def test_session_manager_creates_non_sqlite_database_when_missing(monkeypatch):
+    create_engine_calls = []
+    created = []
+    monkeypatch.setattr("app.database.session_manager.create_engine", lambda url, **kwargs: create_engine_calls.append((url, kwargs)) or "engine")
+    monkeypatch.setattr("app.database.session_manager.database_exists", lambda url: False)
+    monkeypatch.setattr("app.database.session_manager.create_database", lambda url: created.append(url))
+    monkeypatch.setattr("app.database.session_manager.Base.metadata.create_all", lambda bind: None)
+    monkeypatch.setattr("app.database.session_manager.DatabaseSessionManager._import_models", lambda self: None)
+
+    manager = DatabaseSessionManager(
+        configs=SimpleNamespace(database_url="postgresql://db.example/test")
+    )
+
+    assert manager.database_url == "postgresql://db.example/test"
+    assert created == ["postgresql://db.example/test"]
+    assert create_engine_calls[0][1]["pool_pre_ping"] is True
+
+
+def test_session_local_uses_default_db_session_object(monkeypatch):
+    fake_session = object()
+    fake_manager = SimpleNamespace(session_object=lambda: fake_session)
+    monkeypatch.setattr("app.database.session_manager._default_db", fake_manager)
+
+    from app.database.session_manager import session_local
+
+    assert session_local() is fake_session

--- a/tests/utils/test_app_error.py
+++ b/tests/utils/test_app_error.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.utils.app_error import AppError
+
+
+def test_app_error_uses_fallback_error_message_when_error_missing():
+    error = AppError(log_error=False, depth=0)
+
+    assert error.status_code == 400
+    assert error.detail["message"] == "Request failed, please try again."
+    assert "An error occurred" in error.detail["error"]
+
+
+def test_get_caller_details_with_excessive_depth_returns_empty_fields():
+    details = AppError.get_caller_details(10_000)
+
+    assert details == {"file": "", "line": "", "function": ""}
+
+
+def test_log_exception_emits_stacktrace(monkeypatch):
+    messages = []
+    monkeypatch.setattr("app.utils.app_error.logger.error", messages.append)
+
+    error = AppError(log_error=False)
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        error.log_exception()
+
+    assert messages
+    assert messages[0].startswith("StackTrace:")

--- a/tests/utils/test_date_converter.py
+++ b/tests/utils/test_date_converter.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from decimal import Decimal
+
+from app.utils.date_converter import convert_datetime, convert_decimals
+
+
+def test_convert_decimals_handles_nested_containers():
+    payload = {
+        "price": Decimal("19.99"),
+        "items": [Decimal("1.5"), {"tax": Decimal("0.15")}],
+        "name": "book",
+    }
+
+    converted = convert_decimals(payload)
+
+    assert converted == {
+        "price": "19.99",
+        "items": ["1.5", {"tax": "0.15"}],
+        "name": "book",
+    }
+
+
+def test_convert_datetime_handles_nested_containers():
+    now = datetime(2026, 1, 2, 3, 4, 5)
+    payload = {
+        "created_at": now,
+        "items": [now, {"updated_at": now}],
+        "count": 2,
+    }
+
+    converted = convert_datetime(payload)
+
+    assert converted == {
+        "created_at": now.isoformat(),
+        "items": [now.isoformat(), {"updated_at": now.isoformat()}],
+        "count": 2,
+    }
+
+
+def test_converters_leave_non_matching_values_unchanged():
+    assert convert_decimals("plain") == "plain"
+    assert convert_datetime(42) == 42

--- a/tests/utils/test_hash_password.py
+++ b/tests/utils/test_hash_password.py
@@ -1,0 +1,52 @@
+import sys
+import runpy
+
+import pytest
+
+from app.utils.hash_password import (
+    UnknownHashError,
+    _is_bcrypt_hash,
+    hash_password,
+    verify_password,
+)
+
+
+def test_hash_password_and_verify_password_round_trip():
+    hashed = hash_password("MyS3cret!")
+
+    assert hashed != "MyS3cret!"
+    assert verify_password("MyS3cret!", hashed) is True
+    assert verify_password("WrongPass", hashed) is False
+
+
+def test_hash_password_rejects_empty_or_non_string_values():
+    with pytest.raises(ValueError, match="Password must be a non-empty string"):
+        hash_password("")
+
+    with pytest.raises(ValueError, match="Password must be a non-empty string"):
+        hash_password(None)
+
+
+def test_verify_password_rejects_unknown_hashes():
+    with pytest.raises(UnknownHashError, match="hash could not be identified"):
+        verify_password("secret", "plaintext-password")
+
+
+def test_is_bcrypt_hash_handles_non_strings_and_short_values():
+    assert _is_bcrypt_hash(None) is False
+    assert _is_bcrypt_hash("$2b$short") is False
+
+
+def test_hash_password_module_demo_runs_as_main(capsys):
+    module_name = "app.utils.hash_password"
+    original_module = sys.modules.pop(module_name, None)
+
+    try:
+        runpy.run_module(module_name, run_name="__main__")
+    finally:
+        if original_module is not None:
+            sys.modules[module_name] = original_module
+
+    output = capsys.readouterr().out
+    assert "Password:" in output
+    assert "Verify (correct): True" in output

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,40 @@
+import json
+import logging
+
+from app.utils.logging import JsonFormatter, get_uvicorn_log_config
+
+
+def test_json_formatter_includes_extra_context():
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="app",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=12,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    record.extra = {"request_id": "req-1"}
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["message"] == "hello"
+    assert payload["level"] == "INFO"
+    assert payload["request_id"] == "req-1"
+
+
+def test_get_uvicorn_log_config_verbose_mode_uses_debug_root_level():
+    config = get_uvicorn_log_config(verbose=True)
+
+    assert config["root"]["level"] == "DEBUG"
+    assert config["loggers"]["uvicorn"]["level"] == "INFO"
+    assert config["loggers"]["app"]["level"] == "DEBUG"
+
+
+def test_get_uvicorn_log_config_reload_mode_uses_debug_uvicorn_level():
+    config = get_uvicorn_log_config(reload=True, verbose=False)
+
+    assert config["root"]["level"] == "INFO"
+    assert config["loggers"]["uvicorn"]["level"] == "DEBUG"
+    assert config["loggers"]["uvicorn.access"]["propagate"] is False

--- a/tests/utils/test_rate_limiter.py
+++ b/tests/utils/test_rate_limiter.py
@@ -1,0 +1,12 @@
+from collections import deque
+
+from app.utils.rate_limiter import SlidingWindowRateLimiter
+
+
+def test_prune_removes_empty_key_from_internal_store():
+    limiter = SlidingWindowRateLimiter(limit=1, window_seconds=10)
+    limiter._events["email:test@example.com"] = deque([1.0])
+
+    limiter._prune("email:test@example.com", now=20.0)
+
+    assert "email:test@example.com" not in limiter._events

--- a/tests/utils/test_shared_context.py
+++ b/tests/utils/test_shared_context.py
@@ -1,0 +1,70 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.models.user.account_status import UserAccountStatus
+from app.models.user.user import UserReadModel
+from app.utils.shared_context import SharedContext
+
+
+def _build_user(*, status: str = "Active") -> UserReadModel:
+    return UserReadModel(
+        id=1,
+        first_name="Jane",
+        last_name="Doe",
+        email="jane@example.com",
+        phone_number="1234567890",
+        status=status,
+        is_superuser=False,
+    )
+
+
+def test_shared_context_enforces_active_status():
+    with pytest.raises(ValueError, match="Account is not active"):
+        SharedContext(
+            db_session=object(),
+            user=_build_user(status=UserAccountStatus.SUSPENDED.name_value),
+            enforce_status_check=True,
+        )
+
+
+def test_shared_context_user_helpers_and_log_context():
+    context = SharedContext(db_session=object(), user=_build_user())
+
+    assert context.get_user_email() == "jane@example.com"
+    assert context.get_user().first_name == "Jane"
+    assert context.log_context() == {"user_email": "jane@example.com"}
+
+
+def test_shared_context_logging_helpers(monkeypatch):
+    info_calls = []
+    error_calls = []
+    monkeypatch.setattr("app.utils.shared_context.logger.info", lambda *args: info_calls.append(args))
+    monkeypatch.setattr("app.utils.shared_context.logger.error", lambda *args: error_calls.append(args))
+
+    context = SharedContext(db_session=object(), user=_build_user())
+    context.log_info("created")
+    context.log_error("failed")
+
+    assert info_calls == [("user_email=%s, message=%s", "jane@example.com", "created")]
+    assert error_calls == [("user_email=%s, message=%s", "jane@example.com", "failed")]
+
+
+def test_shared_context_safe_json_handles_nested_values():
+    now = datetime(2026, 1, 2, 3, 4, 5)
+    payload = {
+        "today": date(2026, 1, 2),
+        "created_at": now,
+        "amount": Decimal("2.5"),
+        "items": [Decimal("1.0"), {"when": now}],
+    }
+
+    converted = SharedContext.safe_json(payload)
+
+    assert converted == {
+        "today": "2026-01-02",
+        "created_at": now.isoformat(),
+        "amount": 2.5,
+        "items": [1.0, {"when": now.isoformat()}],
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -526,13 +526,14 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.3.1"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690, upload-time = "2026-01-23T15:31:02.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -543,6 +544,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -553,6 +555,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1875,7 +1878,7 @@ wheels = [
 
 [[package]]
 name = "userverse"
-version = "0.6.13"
+version = "0.6.14"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1878,11 +1878,7 @@ wheels = [
 
 [[package]]
 name = "userverse"
-<<<<<<< HEAD
-version = "0.6.14"
-=======
 version = "0.6.15"
->>>>>>> main
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

This PR expands backend test coverage across `tests/database` and `tests/utils`, and fixes a few implementation issues uncovered by the new tests.

## What changed

- Added database tests for:
  - association edge cases
  - base model helpers and JSON field updates
  - session manager defaults
  - company and role helper behavior

- Added utility tests for:
  - app error handling
  - date conversion helpers
  - password hashing helpers
  - logging
  - rate limiting
  - shared context

- Fixed database behavior uncovered by tests:
  - correctly initialize and persist `None` JSON fields in `BaseModel`
  - preserve explicit dict configs in `DatabaseSessionManager`
  - align company-user error messages with expected behavior

- Fixed warning-producing validation handler behavior:
  - replaced deprecated `HTTP_422_UNPROCESSABLE_ENTITY` usage with `HTTP_422_UNPROCESSABLE_CONTENT`

- Removed the warning in the hash password module test by avoiding `runpy` execution against an already-loaded module entry

## Validation

Ran:
- `pytest -v tests/database`
- `pytest -v tests/utils`

Results:
- `tests/database`: `58 passed`
- `tests/utils`: `36 passed`, with the previous warning removed

## Notes

- This PR includes the related `uv.lock` update currently present in the branch.
