### PR TITLE
64 migrate to page based pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ __pycache__/
 *.db
 *.sqlite
 *.sqlite3
-
+# AI
+.codex
 # Distribution / packaging
 .Python
 build/

--- a/app/database/base_model.py
+++ b/app/database/base_model.py
@@ -13,6 +13,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.mutable import MutableDict
 
 from app.utils.date_converter import convert_datetime
+from app.models.generic_pagination import (
+    apply_pagination,
+    build_pagination_meta,
+)
 
 
 from app.utils.logging import logger
@@ -56,6 +60,7 @@ class BaseModel(Base):
         filters: Optional[Dict[str, Any]] = None,
         limit: int = 10,
         page: int = 1,
+        order_by: Optional[List[Any]] = None,
     ) -> Dict[str, Any]:
         """
         Retrieve all records of a model with optional filters and pagination.
@@ -71,8 +76,13 @@ class BaseModel(Base):
         total_records = query.count()
 
         # Apply pagination
-        offset = (page - 1) * limit
-        records = query.offset(offset).limit(limit).all()
+        ordering = order_by or list(cls.__table__.primary_key.columns)
+        records = apply_pagination(
+            query,
+            page=page,
+            limit=limit,
+            order_by=ordering,
+        ).all()
 
         return {
             "records": [cls.to_dict(record) for record in records],
@@ -277,9 +287,8 @@ class BaseModel(Base):
         """
         Generate pagination metadata.
         """
-        return {
-            "total_records": total_records,
-            "limit": limit,
-            "current_page": page,
-            "total_pages": (total_records + limit - 1) // limit,  # Ceiling division
-        }
+        return build_pagination_meta(
+            total_records=total_records,
+            limit=limit,
+            page=page,
+        ).model_dump()

--- a/app/database/base_model.py
+++ b/app/database/base_model.py
@@ -55,7 +55,7 @@ class BaseModel(Base):
         session: Session,
         filters: Optional[Dict[str, Any]] = None,
         limit: int = 10,
-        offset: int = 0,
+        page: int = 1,
     ) -> Dict[str, Any]:
         """
         Retrieve all records of a model with optional filters and pagination.
@@ -71,11 +71,12 @@ class BaseModel(Base):
         total_records = query.count()
 
         # Apply pagination
+        offset = (page - 1) * limit
         records = query.offset(offset).limit(limit).all()
 
         return {
             "records": [cls.to_dict(record) for record in records],
-            "pagination": cls._get_pagination_metadata(total_records, limit, offset),
+            "pagination": cls._get_pagination_metadata(total_records, limit, page),
         }
 
     @classmethod
@@ -271,7 +272,7 @@ class BaseModel(Base):
 
     @staticmethod
     def _get_pagination_metadata(
-        total_records: int, limit: int, offset: int
+        total_records: int, limit: int, page: int
     ) -> Dict[str, int]:
         """
         Generate pagination metadata.
@@ -279,6 +280,6 @@ class BaseModel(Base):
         return {
             "total_records": total_records,
             "limit": limit,
-            "current_page": offset // limit + 1,
+            "current_page": page,
             "total_pages": (total_records + limit - 1) // limit,  # Ceiling division
         }

--- a/app/models/generic_pagination.py
+++ b/app/models/generic_pagination.py
@@ -1,5 +1,5 @@
 # app/models/generic_pagination.py
-from typing import Generic, List, TypeVar
+from typing import Any, Generic, Iterable, List, TypeVar
 from pydantic import BaseModel, Field
 from enum import Enum
 
@@ -21,10 +21,6 @@ class PaginationParams(BaseModel):
     limit: int = Field(10, ge=1, le=100)
     page: int = Field(1, ge=1)  # Page is 1-indexed
 
-    @property
-    def offset(self) -> int:
-        return (self.page - 1) * self.limit
-
 
 class PaginationMeta(BaseModel):
     total_records: int
@@ -36,3 +32,28 @@ class PaginationMeta(BaseModel):
 class PaginatedResponse(BaseModel, Generic[T]):
     records: List[T]
     pagination: PaginationMeta
+
+
+def get_page_offset(*, page: int, limit: int) -> int:
+    return (page - 1) * limit
+
+
+def get_total_pages(*, total_records: int, limit: int) -> int:
+    return (total_records + limit - 1) // limit
+
+
+def build_pagination_meta(
+    *, total_records: int, limit: int, page: int
+) -> PaginationMeta:
+    return PaginationMeta(
+        total_records=total_records,
+        limit=limit,
+        current_page=page,
+        total_pages=get_total_pages(total_records=total_records, limit=limit),
+    )
+
+
+def apply_pagination(query: Any, *, page: int, limit: int, order_by: Iterable[Any]):
+    return query.order_by(*order_by).offset(get_page_offset(page=page, limit=limit)).limit(
+        limit
+    )

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -19,7 +19,11 @@ from app.models.company.company import (
 )
 from app.models.company.roles import CompanyDefaultRoles
 from app.models.company.response_messages import CompanyResponseMessages
-from app.models.generic_pagination import PaginatedResponse, PaginationMeta
+from app.models.generic_pagination import (
+    PaginatedResponse,
+    apply_pagination,
+    build_pagination_meta,
+)
 
 
 class CompanyRepository:
@@ -119,12 +123,13 @@ class CompanyRepository:
 
         total = query.count()
 
-        results = (
-            query.options(joinedload(AssociationUserCompany.company))
-            .offset(params.offset)
-            .limit(params.limit)
-            .all()
+        results = apply_pagination(
+            query.options(joinedload(AssociationUserCompany.company)),
+            page=params.page,
+            limit=params.limit,
+            order_by=[Company.id.asc()],
         )
+        results = results.all()
 
         companies = []
         for assoc in results:
@@ -139,11 +144,10 @@ class CompanyRepository:
 
         return PaginatedResponse[CompanyReadModel](
             records=companies,
-            pagination=PaginationMeta(
+            pagination=build_pagination_meta(
                 total_records=total,
                 limit=params.limit,
-                current_page=params.page,
-                total_pages=(total + params.limit - 1) // params.limit,
+                page=params.page,
             ),
         )
 

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -142,7 +142,7 @@ class CompanyRepository:
             pagination=PaginationMeta(
                 total_records=total,
                 limit=params.limit,
-                current_page=(params.offset // params.limit) + 1,
+                current_page=params.page,
                 total_pages=(total + params.limit - 1) // params.limit,
             ),
         )

--- a/app/repository/company_role.py
+++ b/app/repository/company_role.py
@@ -52,7 +52,7 @@ class RoleRepository:
                 session=session,
                 filters=filters,
                 limit=payload.limit,
-                offset=payload.offset,
+                page=payload.page,
             )
         except Exception as e:
             raise AppError(

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -2,7 +2,11 @@ from fastapi import status
 
 # utils
 from app.models.company.user import CompanyUserAddModel, CompanyUserReadModel
-from app.models.generic_pagination import PaginatedResponse, PaginationMeta
+from app.models.generic_pagination import (
+    PaginatedResponse,
+    apply_pagination,
+    build_pagination_meta,
+)
 from app.utils.app_error import AppError
 
 # database
@@ -86,12 +90,13 @@ class CompanyUserRepository:
 
         total = query.count()
 
-        results = (
-            query.options(joinedload(AssociationUserCompany.user))
-            .offset(params.offset)
-            .limit(params.limit)
-            .all()
+        results = apply_pagination(
+            query.options(joinedload(AssociationUserCompany.user)),
+            page=params.page,
+            limit=params.limit,
+            order_by=[User.id.asc()],
         )
+        results = results.all()
 
         users = [
             CompanyUserReadModel(**User.to_dict(assoc.user), role_name=assoc.role_name)
@@ -100,10 +105,9 @@ class CompanyUserRepository:
 
         return PaginatedResponse[CompanyUserReadModel](
             records=users,
-            pagination=PaginationMeta(
+            pagination=build_pagination_meta(
                 total_records=total,
                 limit=params.limit,
-                current_page=params.page,
-                total_pages=(total + params.limit - 1) // params.limit,
+                page=params.page,
             ),
         )

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -103,7 +103,7 @@ class CompanyUserRepository:
             pagination=PaginationMeta(
                 total_records=total,
                 limit=params.limit,
-                current_page=(params.offset // params.limit) + 1,
+                current_page=params.page,
                 total_pages=(total + params.limit - 1) // params.limit,
             ),
         )

--- a/tests/database/test_base_model_extra.py
+++ b/tests/database/test_base_model_extra.py
@@ -60,6 +60,23 @@ def test_bulk_create_creates_multiple_companies(test_session):
     assert test_session.query(Company).count() == 2
 
 
+def test_get_all_uses_page_based_pagination(test_session):
+    Company.create(test_session, email="page-one@example.com", name="Page One")
+    Company.create(test_session, email="page-two@example.com", name="Page Two")
+    Company.create(test_session, email="page-three@example.com", name="Page Three")
+
+    result = Company.get_all(test_session, limit=2, page=2)
+
+    assert result["pagination"] == {
+        "total_records": 3,
+        "limit": 2,
+        "current_page": 2,
+        "total_pages": 2,
+    }
+    assert len(result["records"]) == 1
+    assert result["records"][0]["email"] == "page-three@example.com"
+
+
 def test_update_json_field_initializes_none_json_column(test_session, test_user_data):
     created = User.create(test_session, **test_user_data["create_user"])
     user = test_session.query(User).filter_by(id=created["id"]).one()

--- a/tests/http/a_user/test_b_user_login_api.py
+++ b/tests/http/a_user/test_b_user_login_api.py
@@ -2,7 +2,7 @@ from app.models.user.response_messages import UserResponseMessages
 from tests.utils.basic_auth import get_basic_auth_header
 
 
-def test_user_login_success(client, test_user_data):
+def test_user_login_success(client, test_user_data, seed_users):
     """Test user login with valid credentials"""
     user_one = test_user_data["user_one"]
     response = client.patch(
@@ -28,7 +28,7 @@ def test_user_login_success(client, test_user_data):
     assert token_data["token_type"] == "bearer"
 
 
-def test_user_login_invalid_credentials(client, test_user_data):
+def test_user_login_invalid_credentials(client, test_user_data, seed_users):
     """Test user login with invalid credentials"""
     user_one = test_user_data["user_one"]
 

--- a/tests/http/c_company_roles/test_g_get_roles.py
+++ b/tests/http/c_company_roles/test_g_get_roles.py
@@ -5,13 +5,18 @@ from app.models.company.response_messages import CompanyRoleResponseMessages
 @pytest.mark.parametrize(
     "query_params,expected_names",
     [
-        ("limit=10&page=1", {"Administrator", "User Updated", "Viewer"}),
+        ("limit=10&page=1", {"Administrator", "Client", "User", "Viewer"}),
         ("limit=10&page=1&name=Ad", {"Administrator"}),
-        ("limit=10&page=1&name=er&description=access", {"User Updated", "Viewer"}),
+        ("limit=10&page=1&name=er&description=access", {"User", "Viewer"}),
     ],
 )
 def test_get_company_roles(
-    client, login_token, test_company_data, query_params, expected_names
+    client,
+    login_token,
+    seed_company_roles,
+    test_company_data,
+    query_params,
+    expected_names,
 ):
     """
     Test getting company roles with optional filters.
@@ -44,7 +49,9 @@ def test_get_company_roles(
     assert pagination["total_records"] == len(expected_names)
 
 
-def test_get_roles_with_invalid_filter(client, login_token, test_company_data):
+def test_get_roles_with_invalid_filter(
+    client, login_token, seed_company_roles, test_company_data
+):
     """
     Test getting company roles with a filter that returns no results.
     """
@@ -62,7 +69,9 @@ def test_get_roles_with_invalid_filter(client, login_token, test_company_data):
     assert json_data["data"]["pagination"]["total_records"] == 0
 
 
-def test_get_roles_with_pagination(client, login_token, test_company_data):
+def test_get_roles_with_pagination(
+    client, login_token, seed_company_roles, test_company_data
+):
     """
     Test pagination with limit=1 and page=2.
     """
@@ -77,7 +86,9 @@ def test_get_roles_with_pagination(client, login_token, test_company_data):
     json_data = response.json()
     assert json_data["message"] == CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value
     assert len(json_data["data"]["records"]) == 1
+    assert json_data["data"]["records"][0]["name"] == "Client"
 
     pagination = json_data["data"]["pagination"]
     assert pagination["limit"] == 1
     assert pagination["current_page"] == 2
+    assert pagination["total_pages"] == 4

--- a/tests/http/c_company_roles/test_g_get_roles.py
+++ b/tests/http/c_company_roles/test_g_get_roles.py
@@ -12,22 +12,21 @@ from app.models.company.response_messages import CompanyRoleResponseMessages
 )
 def test_get_company_roles(
     client,
-    login_token,
-    seed_company_roles,
-    test_company_data,
+    seed_pagination_state,
     query_params,
     expected_names,
 ):
     """
     Test getting company roles with optional filters.
     """
+    company_id = seed_pagination_state["role_company_id"]
     headers = {
-        "Authorization": f"Bearer {login_token}",
+        "Authorization": f"Bearer {seed_pagination_state['owner_token']}",
         "accept": "application/json",
     }
 
     response = client.get(
-        f"/company/1/roles?{query_params}",
+        f"/company/{company_id}/roles?{query_params}",
         headers=headers,
     )
 
@@ -50,17 +49,18 @@ def test_get_company_roles(
 
 
 def test_get_roles_with_invalid_filter(
-    client, login_token, seed_company_roles, test_company_data
+    client, seed_pagination_state
 ):
     """
     Test getting company roles with a filter that returns no results.
     """
+    company_id = seed_pagination_state["role_company_id"]
     headers = {
-        "Authorization": f"Bearer {login_token}",
+        "Authorization": f"Bearer {seed_pagination_state['owner_token']}",
         "accept": "application/json",
     }
 
-    response = client.get("/company/1/roles?name=xyz", headers=headers)
+    response = client.get(f"/company/{company_id}/roles?name=xyz", headers=headers)
     assert response.status_code == 200
 
     json_data = response.json()
@@ -70,17 +70,21 @@ def test_get_roles_with_invalid_filter(
 
 
 def test_get_roles_with_pagination(
-    client, login_token, seed_company_roles, test_company_data
+    client, seed_pagination_state
 ):
     """
     Test pagination with limit=1 and page=2.
     """
+    company_id = seed_pagination_state["role_company_id"]
     headers = {
-        "Authorization": f"Bearer {login_token}",
+        "Authorization": f"Bearer {seed_pagination_state['owner_token']}",
         "accept": "application/json",
     }
 
-    response = client.get("/company/1/roles?limit=1&page=2", headers=headers)
+    response = client.get(
+        f"/company/{company_id}/roles?limit=1&page=2",
+        headers=headers,
+    )
     assert response.status_code == 200
 
     json_data = response.json()

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -10,6 +10,10 @@ from app.main import create_app
 import app.database.session_manager as session_manager
 from app.database.session_manager import DatabaseSessionManager
 from app.database.user import User
+from app.database.company import Company
+from app.database.role import Role
+from app.database.association_user_company import AssociationUserCompany
+from app.models.user.account_status import UserAccountStatus
 from tests.utils.basic_auth import get_basic_auth_header
 from app.security.jwt import JWTManager
 from datetime import timedelta
@@ -84,6 +88,112 @@ def test_company_data():
         return json.load(f)
 
 
+def _get_user_row(email: str):
+    db = DatabaseSessionManager()
+    session = db.session_object()
+    try:
+        return session.query(User).filter_by(email=email.lower()).first()
+    finally:
+        session.close()
+
+
+def _get_company_row(email: str):
+    db = DatabaseSessionManager()
+    session = db.session_object()
+    try:
+        return session.query(Company).filter_by(email=email.lower()).first()
+    finally:
+        session.close()
+
+
+def _get_role_row(company_id: int, name: str):
+    db = DatabaseSessionManager()
+    session = db.session_object()
+    try:
+        return (
+            session.query(Role)
+            .filter_by(company_id=company_id, name=name, _closed_at=None)
+            .first()
+        )
+    finally:
+        session.close()
+
+
+def _get_link_row(company_id: int, user_id: int):
+    db = DatabaseSessionManager()
+    session = db.session_object()
+    try:
+        return (
+            session.query(AssociationUserCompany)
+            .filter_by(company_id=company_id, user_id=user_id, _closed_at=None)
+            .first()
+        )
+    finally:
+        session.close()
+
+
+def _create_user_if_missing(client: TestClient, user: dict):
+    if _get_user_row(user["email"]):
+        return
+
+    payload = {
+        "first_name": user["first_name"],
+        "last_name": user["last_name"],
+        "phone_number": user["phone_number"],
+    }
+    response = client.post(
+        "/user/create",
+        json=payload,
+        headers=get_basic_auth_header(user["email"], user["password"]),
+    )
+    assert response.status_code in [200, 201], response.text
+
+
+def _login_user(client: TestClient, user: dict) -> str:
+    response = client.patch(
+        "/user/login",
+        headers=get_basic_auth_header(user["email"], user["password"]),
+    )
+    assert response.status_code in [200, 201, 202], response.text
+    return response.json()["data"]["access_token"]
+
+
+def _create_company_if_missing(client: TestClient, token: str, company: dict):
+    if _get_company_row(company["email"]):
+        return
+
+    payload = {
+        **company,
+        "address": {
+            "street": "123 Main St",
+            "city": "Johannesburg",
+            "state": "Gauteng",
+            "postal_code": "2000",
+            "country": "South Africa",
+        },
+    }
+    response = client.post(
+        "/company",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code in [200, 201], response.text
+
+
+def _create_role_if_missing(
+    client: TestClient, *, company_id: int, token: str, role_payload: dict
+):
+    if _get_role_row(company_id, role_payload["name"]):
+        return
+
+    response = client.post(
+        f"/company/{company_id}/role",
+        json=role_payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code in [200, 201], response.text
+
+
 @pytest.fixture
 def get_user_two_otp(test_user_data):
     """Get OTP from user metadata."""
@@ -101,28 +211,31 @@ def get_user_two_otp(test_user_data):
         session.close()
 
 
-@pytest.fixture
-def login_token(client, test_user_data):
+@pytest.fixture(scope="session")
+def seed_users(client, test_user_data):
+    for key in ("user_one", "user_two", "user_three"):
+        _create_user_if_missing(client, test_user_data[key])
+
+
+@pytest.fixture(scope="session")
+def seed_verified_users(client, seed_users, test_user_data):
+    for key in ("user_one", "user_two", "user_three"):
+        user = _get_user_row(test_user_data[key]["email"])
+        status = (user.primary_meta_data or {}).get("status") if user else None
+        if status != UserAccountStatus.ACTIVE.name_value:
+            _verify_user_account(client, test_user_data[key]["email"])
+
+
+@pytest.fixture(scope="session")
+def login_token(client, seed_verified_users, test_user_data):
     """Login user_one and return access token."""
-    user = test_user_data["user_one"]
-    response = client.patch(
-        "/user/login",
-        headers=get_basic_auth_header(user["email"], user["password"]),
-    )
-    assert response.status_code in [200, 201, 202]
-    return response.json()["data"]["access_token"]
+    return _login_user(client, test_user_data["user_one"])
 
 
-@pytest.fixture
-def login_token_user_two(client, test_user_data):
+@pytest.fixture(scope="session")
+def login_token_user_two(client, seed_verified_users, test_user_data):
     """Login user_two and return access token."""
-    user = test_user_data["user_two"]
-    response = client.patch(
-        "/user/login",
-        headers=get_basic_auth_header(user["email"], user["password"]),
-    )
-    assert response.status_code in [200, 201, 202]
-    return response.json()["data"]["access_token"]
+    return _login_user(client, test_user_data["user_two"])
 
 
 def _verify_user_account(client: TestClient, email: str):
@@ -147,3 +260,144 @@ def verify_user_two_account(client, test_user_data):
 def verify_both_users(verify_user_one_account, verify_user_two_account):
     # Ensures both users verified before tests
     pass
+
+
+@pytest.fixture(scope="session")
+def seed_companies(client, test_company_data, login_token, login_token_user_two):
+    _create_company_if_missing(client, login_token, test_company_data["company_one"])
+    _create_company_if_missing(
+        client, login_token_user_two, test_company_data["company_two"]
+    )
+
+
+@pytest.fixture(scope="session")
+def seed_company_roles(
+    client, seed_companies, test_company_data, login_token, login_token_user_two
+):
+    for role_payload in test_company_data["roles"].values():
+        _create_role_if_missing(
+            client,
+            company_id=1,
+            token=login_token,
+            role_payload=role_payload,
+        )
+        _create_role_if_missing(
+            client,
+            company_id=2,
+            token=login_token_user_two,
+            role_payload=role_payload,
+        )
+
+
+@pytest.fixture(scope="session")
+def seed_pagination_state(client):
+    owner = {
+        "first_name": "Pagy",
+        "last_name": "Owner",
+        "phone_number": "0333333333",
+        "email": "pagination.owner@email.com",
+        "password": "secureOwner",
+    }
+    _create_user_if_missing(client, owner)
+    owner_row = _get_user_row(owner["email"])
+    owner_status = (owner_row.primary_meta_data or {}).get("status")
+    if owner_status != UserAccountStatus.ACTIVE.name_value:
+        _verify_user_account(client, owner["email"])
+    owner_token = _login_user(client, owner)
+
+    companies = [
+        {
+            "email": "pagination.company.one@email.com",
+            "name": "Pagination Company One",
+            "description": "Dedicated pagination company one.",
+            "industry": "Retail",
+            "phone_number": "+27134567890",
+        },
+        {
+            "email": "pagination.company.two@email.com",
+            "name": "Pagination Company Two",
+            "description": "Dedicated pagination company two.",
+            "industry": "Logistics",
+            "phone_number": "+27145678901",
+        },
+        {
+            "email": "pagination.company.three@email.com",
+            "name": "Pagination Company Three",
+            "description": "Dedicated pagination company three.",
+            "industry": "Energy",
+            "phone_number": "+27156789012",
+        },
+        {
+            "email": "pagination.company.four@email.com",
+            "name": "Pagination Company Four",
+            "description": "Dedicated pagination company four.",
+            "industry": "Media",
+            "phone_number": "+27167890123",
+        },
+    ]
+
+    for company in companies:
+        _create_company_if_missing(client, owner_token, company)
+
+    role_company = _get_company_row("pagination.company.one@email.com")
+    users_company = _get_company_row("pagination.company.two@email.com")
+    user_companies = [
+        _get_company_row("pagination.company.one@email.com"),
+        _get_company_row("pagination.company.two@email.com"),
+        _get_company_row("pagination.company.three@email.com"),
+        _get_company_row("pagination.company.four@email.com"),
+    ]
+
+    for role_payload in (
+        {"name": "User", "description": "Standard user role with limited access."},
+        {"name": "Client", "description": "Client role with access to client features."},
+    ):
+        _create_role_if_missing(
+            client,
+            company_id=role_company.id,
+            token=owner_token,
+            role_payload=role_payload,
+        )
+
+    extra_users = [
+        {
+            "first_name": "Alex",
+            "last_name": "Page",
+            "phone_number": "0111111111",
+            "email": "pagination.user.one@email.com",
+            "password": "secureFour",
+        },
+        {
+            "first_name": "Taylor",
+            "last_name": "Page",
+            "phone_number": "0222222222",
+            "email": "pagination.user.two@email.com",
+            "password": "secureFive",
+        },
+        {
+            "first_name": "Morgan",
+            "last_name": "Page",
+            "phone_number": "0444444444",
+            "email": "pagination.user.three@email.com",
+            "password": "secureSix",
+        },
+    ]
+
+    for user in extra_users:
+        _create_user_if_missing(client, user)
+        user_row = _get_user_row(user["email"])
+        if not _get_link_row(company_id=users_company.id, user_id=user_row.id):
+            response = client.post(
+                f"/company/{users_company.id}/users",
+                json={"email": user["email"], "role": "Viewer"},
+                headers={"Authorization": f"Bearer {owner_token}"},
+            )
+            assert response.status_code == 201, response.text
+
+    return {
+        "owner": owner,
+        "owner_token": owner_token,
+        "role_company_id": role_company.id,
+        "users_company_id": users_company.id,
+        "user_company_ids": [company.id for company in user_companies],
+    }

--- a/tests/http/d_company_users/test_h_get_company_users.py
+++ b/tests/http/d_company_users/test_h_get_company_users.py
@@ -43,6 +43,7 @@ def test_get_users_for_company(
     client,
     login_token,
     login_token_user_two,
+    seed_companies,
     verify_both_users,
     login_token_key,
     company_id,

--- a/tests/http/d_company_users/test_i_get_user_companies.py
+++ b/tests/http/d_company_users/test_i_get_user_companies.py
@@ -24,6 +24,7 @@ def test_get_user_companies(
     client,
     login_token,
     login_token_user_two,
+    seed_companies,
     verify_both_users,
     login_token_key,
     query_params,

--- a/tests/http/test_pagination_regressions.py
+++ b/tests/http/test_pagination_regressions.py
@@ -1,0 +1,87 @@
+from app.models.company.response_messages import (
+    CompanyRoleResponseMessages,
+    CompanyUserResponseMessages,
+)
+
+
+def test_get_company_roles_page_two_is_stable(client, seed_pagination_state):
+    headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
+    company_id = seed_pagination_state["role_company_id"]
+
+    response = client.get(
+        f"/company/{company_id}/roles?limit=2&page=2",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    json_data = response.json()
+    assert json_data["message"] == CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value
+
+    records = json_data["data"]["records"]
+    assert [role["name"] for role in records] == ["User", "Viewer"]
+
+    pagination = json_data["data"]["pagination"]
+    assert pagination == {
+        "total_records": 4,
+        "limit": 2,
+        "current_page": 2,
+        "total_pages": 2,
+    }
+
+
+def test_get_company_users_page_two_is_stable(client, seed_pagination_state):
+    headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
+    company_id = seed_pagination_state["users_company_id"]
+
+    response = client.get(
+        f"/company/{company_id}/users?limit=2&page=2",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    json_data = response.json()
+    assert (
+        json_data["message"] == CompanyUserResponseMessages.GET_COMPANY_USERS.value
+    )
+
+    records = json_data["data"]["records"]
+    assert [user["email"] for user in records] == [
+        "pagination.user.two@email.com",
+        "pagination.user.three@email.com",
+    ]
+
+    pagination = json_data["data"]["pagination"]
+    assert pagination == {
+        "total_records": 4,
+        "limit": 2,
+        "current_page": 2,
+        "total_pages": 2,
+    }
+
+
+def test_get_user_companies_page_two_is_stable(client, seed_pagination_state):
+    headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
+
+    response = client.get(
+        "/user/companies?limit=2&page=2",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    json_data = response.json()
+    assert (
+        json_data["message"] == CompanyUserResponseMessages.GET_COMPANY_USERS.value
+    )
+
+    records = json_data["data"]["records"]
+    assert [company["id"] for company in records] == seed_pagination_state[
+        "user_company_ids"
+    ][2:]
+
+    pagination = json_data["data"]["pagination"]
+    assert pagination == {
+        "total_records": 4,
+        "limit": 2,
+        "current_page": 2,
+        "total_pages": 2,
+    }


### PR DESCRIPTION
## Summary

This PR migrates pagination behavior from offset-based slicing to explicit page-based pagination and makes paginated results deterministic across company roles, company users, and user companies.

It also hardens the HTTP test setup so pagination-related tests seed consistent data and no longer depend on incidental test ordering or previously-created records.

## What Changed

- replaced offset-driven pagination paths with page-based pagination helpers
- centralized pagination math and metadata building in `app/models/generic_pagination.py`
- updated `BaseModel.get_all()` to accept `page` and apply stable ordering before pagination
- updated company role and company user repository queries to use deterministic ordering
- added database-level coverage for page-based pagination metadata
- added regression tests covering page 2 for:
  - company roles
  - company users
  - user companies
- refactored test fixtures to seed users, companies, roles, and pagination-specific data explicitly
- removed the tracked `.codex` file and ignored it in `.gitignore`

## Why

Previously, paginated endpoints could return unstable results because pagination was applied without guaranteed ordering, and some tests relied on mutable shared state. This change makes pagination behavior predictable and ensures page 2 returns the expected records consistently.

## Testing

- added `tests/database/test_base_model_extra.py` coverage for page-based pagination
- added `tests/http/test_pagination_regressions.py`
- updated existing HTTP tests to use seeded fixtures for stable expectations