### PR TITLE
Minor: Migrate user and company IDs to UUIDs

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,56 +1,33 @@
+from __future__ import annotations
+
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-
 from alembic import context
+from sqlalchemy import engine_from_config, pool
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
+from app.configs import settings
+from app.repository.database import Base
+from app.repository.database import tables as database_tables  # noqa: F401
+
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-import sys
-import os
+if settings.DATABASE_URL:
+    config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-from app.database.base_model import BaseModel
-
-target_metadata = BaseModel.metadata
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        compare_type=True,
     )
 
     with context.begin_transaction():
@@ -58,12 +35,6 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -71,7 +42,11 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/alembic/versions/4f9d2f8f6c13_migrate_user_and_company_ids_to_uuid.py
+++ b/alembic/versions/4f9d2f8f6c13_migrate_user_and_company_ids_to_uuid.py
@@ -1,0 +1,454 @@
+"""Migrate user and company IDs to UUID.
+
+Revision ID: 4f9d2f8f6c13
+Revises: 9552b9fc884a
+Create Date: 2026-07-20 20:05:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+from uuid import uuid4
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "4f9d2f8f6c13"
+down_revision: Union[str, None] = "9552b9fc884a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+USER_TEMP = "user_uuid_tmp"
+COMPANY_TEMP = "company_uuid_tmp"
+ROLE_TEMP = "role_uuid_tmp"
+ASSOCIATION_TEMP = "association_user_company_uuid_tmp"
+
+
+def _has_column(columns: list[dict], column_name: str) -> bool:
+    return any(column["name"] == column_name for column in columns)
+
+
+def _create_user_table(*, include_is_superuser: bool) -> None:
+    columns = [
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("first_name", sa.String(length=255), nullable=True),
+        sa.Column("last_name", sa.String(length=255), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("phone_number", sa.String(length=255), nullable=True),
+        sa.Column("password", sa.String(length=255), nullable=False),
+    ]
+    if include_is_superuser:
+        columns.append(
+            sa.Column(
+                "is_superuser",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+    columns.extend(
+        [
+            sa.Column(
+                "_created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+            sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("email"),
+        ]
+    )
+    op.create_table(USER_TEMP, *columns)
+
+
+def _create_company_table() -> None:
+    op.create_table(
+        COMPANY_TEMP,
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=True),
+        sa.Column("description", sa.String(length=512), nullable=True),
+        sa.Column("industry", sa.String(length=128), nullable=True),
+        sa.Column("email", sa.String(length=256), nullable=False),
+        sa.Column("phone_number", sa.String(length=16), nullable=True),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+
+def _create_role_table() -> None:
+    op.create_table(
+        ROLE_TEMP,
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("description", sa.String(length=256), nullable=True),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["company_id"], [f"{COMPANY_TEMP}.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("company_id", "name"),
+    )
+
+
+def _create_association_table() -> None:
+    op.create_table(
+        ASSOCIATION_TEMP,
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("role_name", sa.String(length=256), nullable=False),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], [f"{USER_TEMP}.id"]),
+        sa.ForeignKeyConstraint(["company_id"], [f"{COMPANY_TEMP}.id"]),
+        sa.ForeignKeyConstraint(
+            ["company_id", "role_name"],
+            [f"{ROLE_TEMP}.company_id", f"{ROLE_TEMP}.name"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("user_id", "company_id"),
+    )
+
+
+def _reflect_table(connection, table_name: str) -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(table_name, metadata, autoload_with=connection)
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    user_columns = inspector.get_columns("user")
+    include_is_superuser = _has_column(user_columns, "is_superuser")
+
+    _create_user_table(include_is_superuser=include_is_superuser)
+    _create_company_table()
+    _create_role_table()
+    _create_association_table()
+
+    user_table = _reflect_table(connection, "user")
+    company_table = _reflect_table(connection, "company")
+    role_table = _reflect_table(connection, "role")
+    association_table = _reflect_table(connection, "association_user_company")
+
+    user_target = _reflect_table(connection, USER_TEMP)
+    company_target = _reflect_table(connection, COMPANY_TEMP)
+    role_target = _reflect_table(connection, ROLE_TEMP)
+    association_target = _reflect_table(connection, ASSOCIATION_TEMP)
+
+    user_rows = connection.execute(sa.select(user_table)).mappings().all()
+    company_rows = connection.execute(sa.select(company_table)).mappings().all()
+    role_rows = connection.execute(sa.select(role_table)).mappings().all()
+    association_rows = connection.execute(sa.select(association_table)).mappings().all()
+
+    user_id_map: dict[object, str] = {}
+    company_id_map: dict[object, str] = {}
+
+    for row in user_rows:
+        user_id_map[row["id"]] = str(uuid4())
+    for row in company_rows:
+        company_id_map[row["id"]] = str(uuid4())
+
+    for row in user_rows:
+        payload = {
+            "id": user_id_map[row["id"]],
+            "first_name": row.get("first_name"),
+            "last_name": row.get("last_name"),
+            "email": row["email"],
+            "phone_number": row.get("phone_number"),
+            "password": row["password"],
+            "_created_at": row.get("_created_at"),
+            "_updated_at": row.get("_updated_at"),
+            "_closed_at": row.get("_closed_at"),
+            "primary_meta_data": row.get("primary_meta_data"),
+            "secondary_meta_data": row.get("secondary_meta_data"),
+        }
+        if include_is_superuser:
+            payload["is_superuser"] = bool(row.get("is_superuser", False))
+        connection.execute(sa.insert(user_target).values(**payload))
+
+    for row in company_rows:
+        connection.execute(
+            sa.insert(company_target).values(
+                id=company_id_map[row["id"]],
+                name=row.get("name"),
+                description=row.get("description"),
+                industry=row.get("industry"),
+                email=row["email"],
+                phone_number=row.get("phone_number"),
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    for row in role_rows:
+        connection.execute(
+            sa.insert(role_target).values(
+                company_id=company_id_map[row["company_id"]],
+                name=row["name"],
+                description=row.get("description"),
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    for row in association_rows:
+        connection.execute(
+            sa.insert(association_target).values(
+                user_id=user_id_map[row["user_id"]],
+                company_id=company_id_map[row["company_id"]],
+                role_name=row["role_name"],
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    op.drop_table("association_user_company")
+    op.drop_table("role")
+    op.drop_table("company")
+    op.drop_table("user")
+
+    op.rename_table(USER_TEMP, "user")
+    op.rename_table(COMPANY_TEMP, "company")
+    op.rename_table(ROLE_TEMP, "role")
+    op.rename_table(ASSOCIATION_TEMP, "association_user_company")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    user_columns = inspector.get_columns("user")
+    include_is_superuser = _has_column(user_columns, "is_superuser")
+
+    op.create_table(
+        USER_TEMP,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("first_name", sa.String(length=255), nullable=True),
+        sa.Column("last_name", sa.String(length=255), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("phone_number", sa.String(length=255), nullable=True),
+        sa.Column("password", sa.String(length=255), nullable=False),
+        *(
+            [
+                sa.Column(
+                    "is_superuser",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.text("0"),
+                )
+            ]
+            if include_is_superuser
+            else []
+        ),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_table(
+        COMPANY_TEMP,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=True),
+        sa.Column("description", sa.String(length=512), nullable=True),
+        sa.Column("industry", sa.String(length=128), nullable=True),
+        sa.Column("email", sa.String(length=256), nullable=False),
+        sa.Column("phone_number", sa.String(length=16), nullable=True),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_table(
+        ROLE_TEMP,
+        sa.Column("company_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("description", sa.String(length=256), nullable=True),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["company_id"], [f"{COMPANY_TEMP}.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("company_id", "name"),
+    )
+    op.create_table(
+        ASSOCIATION_TEMP,
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("company_id", sa.Integer(), nullable=False),
+        sa.Column("role_name", sa.String(length=256), nullable=False),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], [f"{USER_TEMP}.id"]),
+        sa.ForeignKeyConstraint(["company_id"], [f"{COMPANY_TEMP}.id"]),
+        sa.ForeignKeyConstraint(
+            ["company_id", "role_name"],
+            [f"{ROLE_TEMP}.company_id", f"{ROLE_TEMP}.name"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("user_id", "company_id"),
+    )
+
+    user_table = _reflect_table(connection, "user")
+    company_table = _reflect_table(connection, "company")
+    role_table = _reflect_table(connection, "role")
+    association_table = _reflect_table(connection, "association_user_company")
+
+    user_target = _reflect_table(connection, USER_TEMP)
+    company_target = _reflect_table(connection, COMPANY_TEMP)
+    role_target = _reflect_table(connection, ROLE_TEMP)
+    association_target = _reflect_table(connection, ASSOCIATION_TEMP)
+
+    user_rows = connection.execute(sa.select(user_table)).mappings().all()
+    company_rows = connection.execute(sa.select(company_table)).mappings().all()
+    role_rows = connection.execute(sa.select(role_table)).mappings().all()
+    association_rows = connection.execute(sa.select(association_table)).mappings().all()
+
+    user_id_map = {row["id"]: index for index, row in enumerate(user_rows, start=1)}
+    company_id_map = {
+        row["id"]: index for index, row in enumerate(company_rows, start=1)
+    }
+
+    for row in user_rows:
+        payload = {
+            "id": user_id_map[row["id"]],
+            "first_name": row.get("first_name"),
+            "last_name": row.get("last_name"),
+            "email": row["email"],
+            "phone_number": row.get("phone_number"),
+            "password": row["password"],
+            "_created_at": row.get("_created_at"),
+            "_updated_at": row.get("_updated_at"),
+            "_closed_at": row.get("_closed_at"),
+            "primary_meta_data": row.get("primary_meta_data"),
+            "secondary_meta_data": row.get("secondary_meta_data"),
+        }
+        if include_is_superuser:
+            payload["is_superuser"] = bool(row.get("is_superuser", False))
+        connection.execute(sa.insert(user_target).values(**payload))
+
+    for row in company_rows:
+        connection.execute(
+            sa.insert(company_target).values(
+                id=company_id_map[row["id"]],
+                name=row.get("name"),
+                description=row.get("description"),
+                industry=row.get("industry"),
+                email=row["email"],
+                phone_number=row.get("phone_number"),
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    for row in role_rows:
+        connection.execute(
+            sa.insert(role_target).values(
+                company_id=company_id_map[row["company_id"]],
+                name=row["name"],
+                description=row.get("description"),
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    for row in association_rows:
+        connection.execute(
+            sa.insert(association_target).values(
+                user_id=user_id_map[row["user_id"]],
+                company_id=company_id_map[row["company_id"]],
+                role_name=row["role_name"],
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    op.drop_table("association_user_company")
+    op.drop_table("role")
+    op.drop_table("company")
+    op.drop_table("user")
+
+    op.rename_table(USER_TEMP, "user")
+    op.rename_table(COMPANY_TEMP, "company")
+    op.rename_table(ROLE_TEMP, "role")
+    op.rename_table(ASSOCIATION_TEMP, "association_user_company")

--- a/app/api/routers/company/company.py
+++ b/app/api/routers/company/company.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, status, Query, Path
 from fastapi.responses import JSONResponse
 
@@ -65,8 +67,8 @@ def create_company_api(
             status_code=status.HTTP_201_CREATED,
             content=GenericResponseModel(
                 message=CompanyResponseMessages.COMPANY_CREATED.value,
-                data=response.model_dump(),
-            ).model_dump(),
+                data=response.model_dump(mode="json"),
+            ).model_dump(mode="json"),
         )
     except (AppError, Exception) as e:
         raise e
@@ -85,7 +87,7 @@ def create_company_api(
 )
 def get_company_api(
     email: str = Query(None, description="(Optional) Company email address"),
-    company_id: int = Query(None, description="(Optional) Company ID"),
+    company_id: UUID | None = Query(None, description="(Optional) Company ID"),
     common_deps: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -115,8 +117,8 @@ def get_company_api(
             status_code=status.HTTP_200_OK,
             content=GenericResponseModel(
                 message=CompanyResponseMessages.COMPANY_FOUND.value,
-                data=company.model_dump(),
-            ).model_dump(),
+                data=company.model_dump(mode="json"),
+            ).model_dump(mode="json"),
         )
     except (AppError, Exception) as e:
         raise e
@@ -134,7 +136,7 @@ def get_company_api(
 )
 def update_company_api(
     company_updates: CompanyUpdateModel,
-    company_id: int = Path(..., description="ID of the company to update"),
+    company_id: UUID = Path(..., description="ID of the company to update"),
     common_deps: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -156,8 +158,8 @@ def update_company_api(
             status_code=status.HTTP_200_OK,
             content=GenericResponseModel(
                 message=CompanyResponseMessages.COMPANY_UPDATED.value,
-                data=response.model_dump(),
-            ).model_dump(),
+                data=response.model_dump(mode="json"),
+            ).model_dump(mode="json"),
         )
     except (AppError, Exception) as e:
         raise e
@@ -175,7 +177,7 @@ def update_company_api(
     },
 )
 def delete_company_api(
-    company_id: int = Path(..., description="ID of the company to delete"),
+    company_id: UUID = Path(..., description="ID of the company to delete"),
     common_deps: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -195,7 +197,7 @@ def delete_company_api(
             content=GenericResponseModel(
                 message=CompanyResponseMessages.COMPANY_DELETED.value,
                 data=None,
-            ).model_dump(),
+            ).model_dump(mode="json"),
         )
     except (AppError, Exception) as e:
         raise e

--- a/app/api/routers/company/roles.py
+++ b/app/api/routers/company/roles.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, status, Path
 from fastapi.responses import JSONResponse
 
@@ -43,7 +45,7 @@ tag = UserverseApiTag.COMPANY_ROLE_MANAGEMENT.name
 )
 def create_role_api(
     payload: RoleCreateModel,
-    company_id: int = Path(..., description="The unique identifier of the company"),
+    company_id: UUID = Path(..., description="The unique identifier of the company"),
     common: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -61,7 +63,7 @@ def create_role_api(
             status_code=status.HTTP_201_CREATED,
             content={
                 "message": CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
-                "data": response.model_dump(),
+                "data": response.model_dump(mode="json"),
             },
         )
     except (AppError, Exception) as e:
@@ -81,7 +83,7 @@ def create_role_api(
 )
 def update_role_api(
     payload: RoleUpdateModel,
-    company_id: int = Path(..., description="The company ID associated with the role"),
+    company_id: UUID = Path(..., description="The company ID associated with the role"),
     name: str = Path(..., description="The name of the role to update"),
     common: CommonJWTRouteDependencies = Depends(),
 ):
@@ -102,7 +104,7 @@ def update_role_api(
             status_code=status.HTTP_201_CREATED,
             content={
                 "message": CompanyRoleResponseMessages.ROLE_UPDATED.value,
-                "data": response.model_dump(),
+                "data": response.model_dump(mode="json"),
             },
         )
     except (AppError, Exception) as e:
@@ -122,7 +124,7 @@ def update_role_api(
 )
 def delete_role_api(
     payload: RoleDeleteModel,
-    company_id: int = Path(..., description="Company ID to delete role from"),
+    company_id: UUID = Path(..., description="Company ID to delete role from"),
     common: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -158,7 +160,7 @@ def delete_role_api(
     },
 )
 def get_company_roles_api(
-    company_id: int = Path(..., description="ID of the company whose roles to fetch"),
+    company_id: UUID = Path(..., description="ID of the company whose roles to fetch"),
     query_params: RoleQueryParamsModel = Depends(),
     common: CommonJWTRouteDependencies = Depends(),
 ):
@@ -179,8 +181,8 @@ def get_company_roles_api(
             status_code=status.HTTP_200_OK,
             content=GenericResponseModel(
                 message=CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value,
-                data=response.model_dump(),
-            ).model_dump(),
+                data=response.model_dump(mode="json"),
+            ).model_dump(mode="json"),
         )
     except (AppError, Exception) as e:
         raise e

--- a/app/api/routers/company/users.py
+++ b/app/api/routers/company/users.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from app.api.dependencies.common import CommonJWTRouteDependencies
 from fastapi import APIRouter, Depends, status, Path
 from fastapi.responses import JSONResponse
@@ -41,7 +43,7 @@ company_id_description = "The ID of the company"
     },
 )
 def get_company_users_api(
-    company_id: int = Path(..., description=company_id_description),
+    company_id: UUID = Path(..., description=company_id_description),
     params: UserQueryParams = Depends(),
     common_dependencies: CommonJWTRouteDependencies = Depends(),
 ):
@@ -65,8 +67,8 @@ def get_company_users_api(
         status_code=status.HTTP_200_OK,
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.GET_COMPANY_USERS.value,
-            data=response.model_dump(),
-        ).model_dump(),
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
     )
 
 
@@ -82,7 +84,7 @@ def get_company_users_api(
 )
 def add_user_to_company_api(
     payload: CompanyUserAddModel,
-    company_id: int = Path(..., description=company_id_description),
+    company_id: UUID = Path(..., description=company_id_description),
     common_dependencies: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -104,8 +106,8 @@ def add_user_to_company_api(
         status_code=status.HTTP_201_CREATED,
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.ADD_USER_SUCCESS.value,
-            data=response.model_dump(),
-        ).model_dump(),
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
     )
 
 
@@ -120,8 +122,8 @@ def add_user_to_company_api(
     },
 )
 def delete_user_from_company_api(
-    company_id: int = Path(..., description=company_id_description),
-    user_id: int = Path(..., description="The ID of the user to remove"),
+    company_id: UUID = Path(..., description=company_id_description),
+    user_id: UUID = Path(..., description="The ID of the user to remove"),
     common_dependencies: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -143,8 +145,8 @@ def delete_user_from_company_api(
         status_code=status.HTTP_200_OK,
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.REMOVE_USER_SUCCESS.value,
-            data=response.model_dump(),
-        ).model_dump(),
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
     )
 
 
@@ -162,8 +164,8 @@ def delete_user_from_company_api(
 )
 def update_user_role_api(
     payload: CompanyUserRoleUpdateModel,
-    company_id: int = Path(..., description=company_id_description),
-    user_id: int = Path(..., description="The ID of the user to update"),
+    company_id: UUID = Path(..., description=company_id_description),
+    user_id: UUID = Path(..., description="The ID of the user to update"),
     common_dependencies: CommonJWTRouteDependencies = Depends(),
 ):
     """
@@ -186,6 +188,6 @@ def update_user_role_api(
         status_code=status.HTTP_200_OK,
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.UPDATE_USER_ROLE_SUCCESS.value,
-            data=response.model_dump(),
-        ).model_dump(),
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
     )

--- a/app/api/routers/user/user_basic_auth_routes.py
+++ b/app/api/routers/user/user_basic_auth_routes.py
@@ -54,7 +54,7 @@ def user_login_api(
         status_code=status.HTTP_202_ACCEPTED,
         content={
             "message": UserResponseMessages.USER_LOGGED_IN.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )
 
@@ -80,7 +80,7 @@ def refresh_user_token_api(
         status_code=status.HTTP_202_ACCEPTED,
         content={
             "message": UserResponseMessages.USER_TOKEN_REFRESHED.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )
 
@@ -107,7 +107,7 @@ def revoke_refresh_token_api(
         status_code=status.HTTP_200_OK,
         content={
             "message": UserResponseMessages.USER_REFRESH_TOKEN_REVOKED.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )
 
@@ -138,6 +138,6 @@ def create_user_api(
         status_code=status.HTTP_201_CREATED,
         content={
             "message": UserResponseMessages.USER_CREATED.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )

--- a/app/api/routers/user/user_password_routes.py
+++ b/app/api/routers/user/user_password_routes.py
@@ -49,7 +49,7 @@ def password_reset_request_api(
     )
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,
-        content=response.model_dump(),
+        content=response.model_dump(mode="json"),
     )
 
 
@@ -78,5 +78,5 @@ def password_reset_validate_otp_api(
     )
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,
-        content=response.model_dump(),
+        content=response.model_dump(mode="json"),
     )

--- a/app/api/routers/user/user_profile_routes.py
+++ b/app/api/routers/user/user_profile_routes.py
@@ -50,7 +50,7 @@ def get_user_api(
         status_code=status.HTTP_200_OK,
         content={
             "message": UserResponseMessages.USER_FOUND.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )
 
@@ -81,7 +81,7 @@ def update_user_api(
         status_code=status.HTTP_201_CREATED,
         content={
             "message": UserResponseMessages.USER_UPDATED.value,
-            "data": response.model_dump(),
+            "data": response.model_dump(mode="json"),
         },
     )
 
@@ -112,8 +112,8 @@ def get_user_companies_api(
         status_code=status.HTTP_200_OK,
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.GET_COMPANY_USERS.value,
-            data=response.model_dump(),
-        ).model_dump(),
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
     )
 
 

--- a/app/api/routers/user/user_verification_routes.py
+++ b/app/api/routers/user/user_verification_routes.py
@@ -39,7 +39,7 @@ def verify_user_account(token: str, session: Session = Depends(get_session)):
     response = UserVerificationService(session).verify_user_account(token=token)
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
-        content=GenericResponseModel(message=response, data=None).model_dump(),
+        content=GenericResponseModel(message=response, data=None).model_dump(mode="json"),
     )
 
 
@@ -70,5 +70,5 @@ def resend_verification_email(
     )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content=response.model_dump(),
+        content=response.model_dump(mode="json"),
     )

--- a/app/api/security/jwt.py
+++ b/app/api/security/jwt.py
@@ -45,13 +45,13 @@ class JWTManager:
         refresh_expire = now + timedelta(minutes=self.REFRESH_TIMEOUT)
 
         access_payload = {
-            "user": user.model_dump(),
+            "user": user.model_dump(mode="json"),
             "type": "access",
             "exp": access_expire,
         }
 
         refresh_payload = {
-            "user": user.model_dump(),
+            "user": user.model_dump(mode="json"),
             "type": "refresh",
             "refresh_token_version": refresh_token_version,
             "exp": refresh_expire,

--- a/app/models/company/company.py
+++ b/app/models/company/company.py
@@ -1,4 +1,6 @@
 from typing import Optional
+from uuid import UUID
+
 from app.models.company.address import CompanyAddressModel
 from pydantic import BaseModel, EmailStr, field_validator, Field
 from app.models.phone_number import validate_phone_number_format
@@ -6,7 +8,7 @@ from app.models.generic_pagination import PaginationParams
 
 
 class CompanyReadModel(BaseModel):
-    id: int
+    id: UUID
     name: Optional[str] = None
     description: Optional[str] = None
     industry: Optional[str] = None

--- a/app/models/user/user.py
+++ b/app/models/user/user.py
@@ -1,4 +1,6 @@
 from typing import Optional, Literal
+from uuid import UUID
+
 from pydantic import BaseModel, EmailStr, field_validator, Field
 from app.models.phone_number import validate_phone_number_format
 from app.models.generic_pagination import PaginationParams
@@ -35,7 +37,7 @@ class UserCreateModel(BaseModel):
 
 
 class UserReadModel(BaseModel):
-    id: int
+    id: UUID
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     email: EmailStr

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
@@ -36,7 +38,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
             data["address"] = primary_meta_data["address"]
         return CompanyReadModel(**data)
 
-    def _get_company_record_by_id(self, company_id: int) -> Company | None:
+    def _get_company_record_by_id(self, company_id: UUID) -> Company | None:
         return (
             self._base_query()
             .filter(Company.id == company_id, Company._closed_at.is_(None))
@@ -102,8 +104,8 @@ class CompanyRepository(BaseSQLRepository[Company]):
         company = self._get_company_record_by_id(company.id)
         return self._to_read_model(company)
 
-    def get_company_by_id(self, company_id: str) -> CompanyReadModel:
-        company = self._get_company_record_by_id(int(company_id))
+    def get_company_by_id(self, company_id: UUID) -> CompanyReadModel:
+        company = self._get_company_record_by_id(company_id)
         if not company:
             raise AppError(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -121,9 +123,9 @@ class CompanyRepository(BaseSQLRepository[Company]):
         return self._to_read_model(company)
 
     def update_company(
-        self, payload: CompanyUpdateModel, company_id: str, user
+        self, payload: CompanyUpdateModel, company_id: UUID, user
     ) -> CompanyReadModel:
-        company = self._get_company_record_by_id(int(company_id))
+        company = self._get_company_record_by_id(company_id)
         if not company:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -142,8 +144,8 @@ class CompanyRepository(BaseSQLRepository[Company]):
             )
         return self._to_read_model(company)
 
-    def delete_company(self, company_id: str) -> None:
-        company = self._get_company_record_by_id(int(company_id))
+    def delete_company(self, company_id: UUID) -> None:
+        company = self._get_company_record_by_id(company_id)
         if not company:
             raise AppError(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -153,7 +155,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
         self.soft_delete(company)
 
     def get_user_companies(
-        self, user_id: int, params: CompanyQueryParamsModel
+        self, user_id: UUID, params: CompanyQueryParamsModel
     ) -> PaginatedResponse[CompanyReadModel]:
         query = (
             self.db_session.query(AssociationUserCompany)
@@ -182,7 +184,10 @@ class CompanyRepository(BaseSQLRepository[Company]):
             query.options(joinedload(AssociationUserCompany.company)),
             page=params.page,
             limit=params.limit,
-            order_by=[Company.id.asc()],
+            order_by=[
+                AssociationUserCompany._created_at.asc(),
+                Company.id.asc(),
+            ],
         ).all()
         companies = [self._to_read_model(assoc.company) for assoc in results]
         return PaginatedResponse[CompanyReadModel](

--- a/app/repository/company_role.py
+++ b/app/repository/company_role.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 
 from app.models.company.response_messages import (
@@ -20,7 +22,7 @@ from app.utils.app_error import AppError
 class RoleRepository(BaseSQLRepository[Role]):
     model = Role
 
-    def __init__(self, company_id: int, session):
+    def __init__(self, company_id: UUID, session):
         super().__init__(session)
         self.company_id = company_id
 
@@ -100,7 +102,7 @@ class RoleRepository(BaseSQLRepository[Role]):
                 role_to_delete,
                 column_name="primary_meta_data",
                 key="deleted_by",
-                value=deleted_by.model_dump(),
+                value=deleted_by.model_dump(mode="json"),
             )
 
             return {
@@ -151,7 +153,7 @@ class RoleRepository(BaseSQLRepository[Role]):
                 role,
                 column_name="primary_meta_data",
                 key="created_by",
-                value=created_by.model_dump(),
+                value=created_by.model_dump(mode="json"),
             )
             return self._to_read_model(role)
         except Exception as exc:

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.orm.attributes import flag_modified
@@ -41,8 +43,8 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
 
     def is_user_linked_to_company(
         self,
-        user_id: int,
-        company_id: int,
+        user_id: UUID,
+        company_id: UUID,
         role_name: str | None = None,
         role: str | None = None,
     ) -> bool:
@@ -57,7 +59,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         return self.db_session.query(query.exists()).scalar()
 
     def ensure_user_linked_to_company(
-        self, user_id: int, company_id: int, role_name: str | None = None
+        self, user_id: UUID, company_id: UUID, role_name: str | None = None
     ) -> bool:
         linked_company = self.is_user_linked_to_company(user_id, company_id, role_name)
         if not linked_company:
@@ -68,7 +70,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         return linked_company
 
     def add_user_to_company(
-        self, company_id: int, payload: CompanyUserAddModel, added_by
+        self, company_id: UUID, payload: CompanyUserAddModel, added_by
     ) -> CompanyUserReadModel:
         user = self.db_session.query(User).filter(User.email == payload.email).first()
         if not user:
@@ -109,12 +111,12 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             user_id=user.id,
             company_id=company_id,
             role_name=role.name,
-            primary_meta_data={"added_by": added_by.model_dump()},
+            primary_meta_data={"added_by": added_by.model_dump(mode="json")},
         )
         return self._to_company_user(user, assoc.role_name)
 
     def remove_user_from_company(
-        self, company_id: int, user_id: int, removed_by
+        self, company_id: UUID, user_id: UUID, removed_by
     ) -> CompanyUserReadModel:
         assoc = (
             self._base_query()
@@ -136,7 +138,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
                 message=CompanyUserResponseMessages.SUPER_ADMIN_REMOVE_FORBIDDEN.value,
             )
 
-        assoc.primary_meta_data["removed_by"] = removed_by.model_dump()
+        assoc.primary_meta_data["removed_by"] = removed_by.model_dump(mode="json")
         flag_modified(assoc, "primary_meta_data")
         assoc._closed_at = self._now_sql()
         self.db_session.add(assoc)
@@ -147,7 +149,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         return self._to_company_user(user, assoc.role_name)
 
     def update_user_role(
-        self, company_id: int, user_id: int, role_name: str, updated_by
+        self, company_id: UUID, user_id: UUID, role_name: str, updated_by
     ) -> CompanyUserReadModel:
         role = (
             self.db_session.query(Role)
@@ -178,7 +180,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             )
 
         assoc.role_name = role.name
-        assoc.primary_meta_data["updated_by"] = updated_by.model_dump()
+        assoc.primary_meta_data["updated_by"] = updated_by.model_dump(mode="json")
         flag_modified(assoc, "primary_meta_data")
         self.db_session.add(assoc)
         self.db_session.commit()
@@ -188,7 +190,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         return self._to_company_user(user, assoc.role_name)
 
     def get_company_users(
-        self, company_id: int, params: UserQueryParams
+        self, company_id: UUID, params: UserQueryParams
     ) -> PaginatedResponse[CompanyUserReadModel]:
         query = (
             self.db_session.query(AssociationUserCompany)
@@ -216,7 +218,10 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             query.options(joinedload(AssociationUserCompany.user)),
             page=params.page,
             limit=params.limit,
-            order_by=[User.id.asc()],
+            order_by=[
+                AssociationUserCompany._created_at.asc(),
+                User.id.asc(),
+            ],
         ).all()
 
         users = [

--- a/app/repository/database/base_model.py
+++ b/app/repository/database/base_model.py
@@ -70,7 +70,10 @@ class BaseModel(TimestampMixin, Base):
             for condition in filters.values():
                 query = query.filter(condition)
         total_records = query.count()
-        ordering = order_by or list(cls.__table__.primary_key.columns)
+        ordering = order_by or [
+            cls._created_at.asc(),
+            *[column.asc() for column in cls.__table__.primary_key.columns],
+        ]
         records = apply_pagination(
             query,
             page=page,

--- a/app/repository/database/tables/association_user_company.py
+++ b/app/repository/database/tables/association_user_company.py
@@ -1,4 +1,6 @@
-from sqlalchemy import ForeignKey, ForeignKeyConstraint, Integer, String
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, ForeignKeyConstraint, String, Uuid
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -15,13 +17,13 @@ from sqlalchemy.sql import func
 class AssociationUserCompany(BaseModel):
     __tablename__ = "association_user_company"
 
-    user_id: Mapped[int] = mapped_column(
-        Integer,
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid,
         ForeignKey("user.id"),
         primary_key=True,
     )
-    company_id: Mapped[int] = mapped_column(
-        Integer,
+    company_id: Mapped[UUID] = mapped_column(
+        Uuid,
         ForeignKey("company.id"),
         primary_key=True,
     )
@@ -43,8 +45,8 @@ class AssociationUserCompany(BaseModel):
     def is_user_linked_to_company(
         cls,
         session: Session,
-        user_id: int,
-        company_id: int,
+        user_id: UUID,
+        company_id: UUID,
         role_name: str | None = None,
     ) -> bool:
         query = session.query(cls).filter_by(user_id=user_id, company_id=company_id)
@@ -56,8 +58,8 @@ class AssociationUserCompany(BaseModel):
     def link_user(
         cls,
         session: Session,
-        company_id: int,
-        user_id: int,
+        company_id: UUID,
+        user_id: UUID,
         role_name: str,
         added_by: UserReadModel,
     ) -> "AssociationUserCompany":
@@ -73,7 +75,7 @@ class AssociationUserCompany(BaseModel):
             user_id=user_id,
             company_id=company_id,
             role_name=role_name,
-            primary_meta_data={"added_by": added_by.model_dump()},
+            primary_meta_data={"added_by": added_by.model_dump(mode="json")},
         )
         session.add(assoc)
         session.commit()
@@ -84,8 +86,8 @@ class AssociationUserCompany(BaseModel):
     def unlink_user(
         cls,
         session: Session,
-        company_id: int,
-        user_id: int,
+        company_id: UUID,
+        user_id: UUID,
         removed_by: UserReadModel,
     ) -> "AssociationUserCompany":
         assoc = (
@@ -106,7 +108,7 @@ class AssociationUserCompany(BaseModel):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 message=CompanyUserResponseMessages.SUPER_ADMIN_REMOVE_FORBIDDEN.value,
             )
-        assoc.primary_meta_data["removed_by"] = removed_by.model_dump()
+        assoc.primary_meta_data["removed_by"] = removed_by.model_dump(mode="json")
         flag_modified(assoc, "primary_meta_data")
         assoc._closed_at = func.now()
         session.commit()

--- a/app/repository/database/tables/company.py
+++ b/app/repository/database/tables/company.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Integer, String
+from uuid import UUID, uuid4
+
+from sqlalchemy import String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.repository.database.base_model import BaseModel
@@ -7,7 +9,11 @@ from app.repository.database.base_model import BaseModel
 class Company(BaseModel):
     __tablename__ = "company"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=uuid4,
+    )
     name: Mapped[str | None] = mapped_column(String(256), nullable=True)
     description: Mapped[str | None] = mapped_column(String(512), nullable=True)
     industry: Mapped[str | None] = mapped_column(String(128), nullable=True)

--- a/app/repository/database/tables/role.py
+++ b/app/repository/database/tables/role.py
@@ -1,4 +1,6 @@
-from sqlalchemy import ForeignKey, Integer, String
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String, Uuid
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
@@ -14,8 +16,8 @@ from fastapi import status
 class Role(BaseModel):
     __tablename__ = "role"
 
-    company_id: Mapped[int] = mapped_column(
-        Integer,
+    company_id: Mapped[UUID] = mapped_column(
+        Uuid,
         ForeignKey("company.id", ondelete="CASCADE"),
         primary_key=True,
     )
@@ -31,7 +33,7 @@ class Role(BaseModel):
 
     @classmethod
     def role_belongs_to_company(
-        cls, session: Session, company_id: int, role_name: str
+        cls, session: Session, company_id: UUID, role_name: str
     ) -> dict:
         role = (
             session.query(cls)
@@ -50,7 +52,7 @@ class Role(BaseModel):
     def update_role(
         cls,
         session: Session,
-        company_id: int,
+        company_id: UUID,
         name: str,
         new_name: str | None = None,
         new_description: str | None = None,
@@ -73,7 +75,7 @@ class Role(BaseModel):
     def update_json_field(
         cls,
         session: Session,
-        company_id: int,
+        company_id: UUID,
         name: str,
         column_name: str,
         key: str,
@@ -101,7 +103,7 @@ class Role(BaseModel):
     def delete_role_and_reassign_users(
         cls,
         session: Session,
-        company_id: int,
+        company_id: UUID,
         name_to_delete: str,
         replacement_name: str,
         deleted_by: UserReadModel,
@@ -139,7 +141,7 @@ class Role(BaseModel):
             name=name_to_delete,
             column_name="primary_meta_data",
             key="deleted_by",
-            value=deleted_by.model_dump(),
+            value=deleted_by.model_dump(mode="json"),
         )
         session.refresh(role_to_delete)
         return {

--- a/app/repository/database/tables/user.py
+++ b/app/repository/database/tables/user.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Boolean, Integer, String
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, String, Uuid
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -9,7 +11,11 @@ from app.repository.database.base_model import BaseModel
 class User(BaseModel):
     __tablename__ = "user"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=uuid4,
+    )
     first_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)

--- a/app/repository/user.py
+++ b/app/repository/user.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 from sqlalchemy.exc import IntegrityError
 
@@ -32,7 +34,7 @@ class UserRepository(BaseSQLRepository[User]):
             is_superuser=user.is_superuser,
         )
 
-    def get_user_by_id(self, user_id: int) -> UserReadModel:
+    def get_user_by_id(self, user_id: UUID) -> UserReadModel:
         try:
             user = self._active_user_query().filter(User.id == user_id).one_or_none()
             if user is None:
@@ -110,7 +112,7 @@ class UserRepository(BaseSQLRepository[User]):
         self.db_session.refresh(user)
         return self._to_read_model(user, status_override=account_status)
 
-    def update_user(self, user_id: int, data: dict) -> UserReadModel:
+    def update_user(self, user_id: UUID, data: dict) -> UserReadModel:
         user = self._active_user_query().filter(User.id == user_id).one_or_none()
         if not user:
             raise AppError(
@@ -120,7 +122,7 @@ class UserRepository(BaseSQLRepository[User]):
         updated = self.update(user, **data)
         return self._to_read_model(updated)
 
-    def update_user_status(self, user_id: int, account_status: str) -> UserReadModel:
+    def update_user_status(self, user_id: UUID, account_status: str) -> UserReadModel:
         user = self._active_user_query().filter(User.id == user_id).one_or_none()
         if not user:
             raise AppError(
@@ -135,7 +137,7 @@ class UserRepository(BaseSQLRepository[User]):
         )
         return self._to_read_model(updated, status_override=account_status)
 
-    def get_refresh_token_version(self, user_id: int) -> int:
+    def get_refresh_token_version(self, user_id: UUID) -> int:
         user = self._active_user_query().filter(User.id == user_id).first()
         if not user:
             raise AppError(
@@ -150,7 +152,7 @@ class UserRepository(BaseSQLRepository[User]):
         except (TypeError, ValueError):
             return 0
 
-    def increment_refresh_token_version(self, user_id: int) -> int:
+    def increment_refresh_token_version(self, user_id: UUID) -> int:
         user = self._active_user_query().filter(User.id == user_id).first()
         if not user:
             raise AppError(
@@ -170,7 +172,7 @@ class UserRepository(BaseSQLRepository[User]):
             )
         )
 
-    def delete_user(self, user_id: int):
+    def delete_user(self, user_id: UUID):
         user = self._active_user_query().filter(User.id == user_id).one_or_none()
         if not user:
             raise AppError(

--- a/app/services/company/company.py
+++ b/app/services/company/company.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 
 # utils
@@ -44,7 +46,7 @@ class CompanyService:
         return company
 
     def get_company(
-        self, company_id: str = None, email: str = None
+        self, company_id: UUID | None = None, email: str | None = None
     ) -> CompanyReadModel:
         """
         Get a company by its ID.
@@ -69,7 +71,7 @@ class CompanyService:
         return company
 
     def update_company(
-        self, payload: CompanyUpdateModel, company_id: str
+        self, payload: CompanyUpdateModel, company_id: UUID
     ) -> CompanyReadModel:
         """
         Update a company by its ID.
@@ -101,7 +103,7 @@ class CompanyService:
             )
         return company
 
-    def delete_company(self, company_id: str) -> None:
+    def delete_company(self, company_id: UUID) -> None:
         self.company_user_service.check_if_user_is_in_company(
             user_id=self.context.user.id,
             company_id=company_id,

--- a/app/services/company/role.py
+++ b/app/services/company/role.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 
 # utils
@@ -27,7 +29,7 @@ class RoleService:
     def __init__(self, context: SharedContext):
         self.context = context
 
-    def _ensure_company_manager(self, company_id: int) -> None:
+    def _ensure_company_manager(self, company_id: UUID) -> None:
         company_user_service = CompanyUserService(self.context)
         if not (
             company_user_service.company_user_repository.is_user_linked_to_company(
@@ -47,7 +49,7 @@ class RoleService:
             )
 
     def update_role(
-        self, company_id: int, name: str, payload: RoleUpdateModel
+        self, company_id: UUID, name: str, payload: RoleUpdateModel
     ) -> RoleReadModel:
         """
         Update the description or name of a role for a company.
@@ -67,7 +69,7 @@ class RoleService:
             )
         return role
 
-    def create_role(self, payload: RoleCreateModel, company_id: int) -> RoleReadModel:
+    def create_role(self, payload: RoleCreateModel, company_id: UUID) -> RoleReadModel:
         """
         Create a new company role and store its creator in primary_meta_data.
         """
@@ -83,7 +85,7 @@ class RoleService:
             )
         return role
 
-    def delete_role(self, payload: RoleDeleteModel, company_id: int) -> dict:
+    def delete_role(self, payload: RoleDeleteModel, company_id: UUID) -> dict:
         self._ensure_company_manager(company_id)
         role_repository = RoleRepository(
             company_id=company_id, session=self.context.db_session
@@ -93,7 +95,7 @@ class RoleService:
         )
 
     def get_company_roles(
-        self, payload: RoleQueryParamsModel, company_id: int
+        self, payload: RoleQueryParamsModel, company_id: UUID
     ) -> PaginatedResponse[RoleReadModel]:
         """
         Get company roles with pagination and optional filtering.

--- a/app/services/company/user.py
+++ b/app/services/company/user.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import status
 
 # utils
@@ -68,7 +70,7 @@ class CompanyUserService:
             )
 
     def add_user_to_company(
-        self, company_id: int, payload: CompanyUserAddModel
+        self, company_id: UUID, payload: CompanyUserAddModel
     ) -> CompanyUserReadModel:
         if not (
             self.company_user_repository.is_user_linked_to_company(
@@ -101,8 +103,8 @@ class CompanyUserService:
 
     def update_user_role(
         self,
-        company_id: int,
-        user_id: int,
+        company_id: UUID,
+        user_id: UUID,
         payload: CompanyUserRoleUpdateModel,
     ) -> CompanyUserReadModel:
         if not (
@@ -130,8 +132,8 @@ class CompanyUserService:
 
     def remove_user_from_company(
         self,
-        company_id: int,
-        user_id: int,
+        company_id: UUID,
+        user_id: UUID,
     ) -> CompanyUserReadModel:
         if not (
             self.company_user_repository.is_user_linked_to_company(
@@ -167,7 +169,7 @@ class CompanyUserService:
 
     def get_company_users(
         self,
-        company_id: int,
+        company_id: UUID,
         params: UserQueryParams,
     ) -> PaginatedResponse[CompanyUserReadModel]:
         self.check_if_user_is_in_company(
@@ -180,7 +182,7 @@ class CompanyUserService:
         )
 
     def check_if_user_is_in_company(
-        self, user_id: int, company_id: int, role: str | None = None
+        self, user_id: UUID, company_id: UUID, role: str | None = None
     ) -> bool:
         """
         Check if the user is linked to the company.

--- a/app/services/user/profile.py
+++ b/app/services/user/profile.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 from app.utils.shared_context import SharedContext
 from app.repository.user import UserRepository
 from app.repository.company import CompanyRepository
@@ -22,7 +23,7 @@ class UserProfileService:
         self.company_repository = CompanyRepository(context.db_session)
 
     def get_user(
-        self, user_id: Optional[int] = None, user_email: Optional[str] = None
+        self, user_id: Optional[UUID] = None, user_email: Optional[str] = None
     ) -> UserReadModel:
         """
         Get user profile information.
@@ -38,7 +39,7 @@ class UserProfileService:
             message=UserResponseMessages.USER_NOT_FOUND.value,
         )
 
-    def update_user(self, user_id: int, user_data: UserUpdateModel) -> UserReadModel:
+    def update_user(self, user_id: UUID, user_data: UserUpdateModel) -> UserReadModel:
         """
         Update user profile information.
         This method allows updating user details such as name, phone number, and password.
@@ -70,7 +71,7 @@ class UserProfileService:
             user_id=self.context.user.id, params=params
         )
 
-    def delete_user(self, user_id: int) -> None:
+    def delete_user(self, user_id: UUID) -> None:
         """
         Soft-delete the authenticated user account.
         """

--- a/tests/api/http/b_company/test_b_get_company.py
+++ b/tests/api/http/b_company/test_b_get_company.py
@@ -1,10 +1,12 @@
 from app.models.company.response_messages import CompanyResponseMessages
+from uuid import uuid4
 
 
 def test_a_get_company_one_by_id_success(client, login_token, seed_companies):
     """Test creating Company One using User One's token"""
+    company_id = seed_companies["company_one"]
     headers = {"Authorization": f"Bearer {login_token}"}
-    response = client.get(f"/company?company_id={1}", headers=headers)
+    response = client.get(f"/company?company_id={company_id}", headers=headers)
     #
     assert response.status_code in [200, 201]
     json_data = response.json()
@@ -12,7 +14,7 @@ def test_a_get_company_one_by_id_success(client, login_token, seed_companies):
     assert "message" in json_data
     assert json_data["message"] == CompanyResponseMessages.COMPANY_FOUND.value
     assert "data" in json_data
-    assert json_data["data"]["id"] == 1
+    assert json_data["data"]["id"] == str(company_id)
     assert json_data["data"]["name"] == "Company One"
     assert json_data["data"]["email"] == "company.one@email.com"
 
@@ -30,7 +32,7 @@ def test_b_get_company_one_by_email_success(
     assert "message" in json_data
     assert json_data["message"] == CompanyResponseMessages.COMPANY_FOUND.value
     assert "data" in json_data
-    assert json_data["data"]["id"] == 1
+    assert json_data["data"]["id"] == str(seed_companies["company_one"])
 
 
 def test_c_get_company_invalid_args(client, login_token):
@@ -53,7 +55,7 @@ def test_d_get_company_not_found(client, login_token, seed_companies):
     """Test creating Company One using User One's token"""
     headers = {"Authorization": f"Bearer {login_token}"}
 
-    response = client.get("/company?company_id=99999", headers=headers)
+    response = client.get(f"/company?company_id={uuid4()}", headers=headers)
 
     assert response.status_code == 404
     json_data = response.json()
@@ -66,8 +68,9 @@ def test_d_get_company_not_found(client, login_token, seed_companies):
 
 def test_e_get_company_without_associated(client, login_token, seed_companies):
     """Test getting a company that you are not associated with"""
+    company_id = seed_companies["company_two"]
     headers = {"Authorization": f"Bearer {login_token}"}
-    response = client.get("/company?company_id=2", headers=headers)
+    response = client.get(f"/company?company_id={company_id}", headers=headers)
 
     assert response.status_code == 403
     json_data = response.json()

--- a/tests/api/http/b_company/test_c_update_company.py
+++ b/tests/api/http/b_company/test_c_update_company.py
@@ -7,12 +7,13 @@ def test_a_update_company_one_success(
     """
     Test updating a company successfully.
     """
+    company_id = seed_companies["company_one"]
     headers = {"Authorization": f"Bearer {login_token}"}
     payload = {
         **test_company_data["update_company_one"],
         "address": test_company_data["json_field"]["updated_value"],
     }
-    response = client.patch("/company/1", json=payload, headers=headers)
+    response = client.patch(f"/company/{company_id}", json=payload, headers=headers)
     #
     assert response.status_code in [200, 201]
     json_data = response.json()
@@ -20,7 +21,7 @@ def test_a_update_company_one_success(
     assert "message" in json_data
     assert json_data["message"] == CompanyResponseMessages.COMPANY_UPDATED.value
     assert "data" in json_data
-    assert json_data["data"]["id"] == 1
+    assert json_data["data"]["id"] == str(company_id)
     assert json_data["data"]["name"] == test_company_data["update_company_one"]["name"]
     assert (
         json_data["data"]["address"]["city"]
@@ -50,12 +51,13 @@ def test_b_update_company_two_failure(
     """
     Test updating a company, but the user is not an admin.
     """
+    company_id = seed_companies["company_two"]
     headers = {"Authorization": f"Bearer {login_token}"}
     payload = {
         **test_company_data["update_company_one"],
         "address": test_company_data["json_field"]["updated_value"],
     }
-    response = client.patch("/company/2", json=payload, headers=headers)
+    response = client.patch(f"/company/{company_id}", json=payload, headers=headers)
     #
     assert response.status_code in [400, 401, 403]
     json_data = response.json()

--- a/tests/api/http/c_company_roles/test_d_create_role.py
+++ b/tests/api/http/c_company_roles/test_d_create_role.py
@@ -15,11 +15,14 @@ def test_a_create_company_one_roles_success(
     """
     Test creating roles for a company successfully.
     """
+    company_id = seed_companies["company_one"]
     roles = test_company_data["roles"]
     headers = {"Authorization": f"Bearer {login_token}"}
 
     for role_key, role_value in roles.items():
-        response = client.post("/company/1/role", json=role_value, headers=headers)
+        response = client.post(
+            f"/company/{company_id}/role", json=role_value, headers=headers
+        )
         #
         assert response.status_code in [200, 201]
         json_data = response.json()
@@ -40,11 +43,14 @@ def test_a_create_company_two_roles_success(
     """
     Test creating roles for a company successfully.
     """
+    company_id = seed_companies["company_two"]
     roles = test_company_data["roles"]
     headers = {"Authorization": f"Bearer {login_token_user_two}"}
 
     for role_key, role_value in roles.items():
-        response = client.post("/company/2/role", json=role_value, headers=headers)
+        response = client.post(
+            f"/company/{company_id}/role", json=role_value, headers=headers
+        )
         #
         assert response.status_code in [200, 201]
         json_data = response.json()
@@ -65,11 +71,14 @@ def test_b_create_company_roles_failure(
     """
     Test creating roles for a company failure. When the user is not authorized to create roles.
     """
+    company_id = seed_companies["company_one"]
     roles = test_company_data["roles"]
     headers = {"Authorization": f"Bearer {login_token_user_two}"}
 
     for role_key, role_value in roles.items():
-        response = client.post("/company/1/role", json=role_value, headers=headers)
+        response = client.post(
+            f"/company/{company_id}/role", json=role_value, headers=headers
+        )
         #
         assert response.status_code in [400, 403]
         json_data = response.json()
@@ -87,11 +96,14 @@ def test_c_create_company_roles_failure(
     """
     Test creating roles for a company failure. When the roles already exist
     """
+    company_id = seed_companies["company_two"]
     roles = test_company_data["roles"]
     headers = {"Authorization": f"Bearer {login_token_user_two}"}
 
     for role_key, role_value in roles.items():
-        response = client.post("/company/2/role", json=role_value, headers=headers)
+        response = client.post(
+            f"/company/{company_id}/role", json=role_value, headers=headers
+        )
         #
         assert response.status_code in [400, 403]
         json_data = response.json()

--- a/tests/api/http/c_company_roles/test_e_update_role.py
+++ b/tests/api/http/c_company_roles/test_e_update_role.py
@@ -10,6 +10,7 @@ def test_a_update_role_description_success(
     """
     Test updating a role's description successfully.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {"Authorization": f"Bearer {login_token}"}
     # Assume company 1 and role 'Admin' exist
     payload = test_company_data["roles"]
@@ -19,7 +20,9 @@ def test_a_update_role_description_success(
             "name": name + " Updated",
             "description": role_value["description"] + " Updated",
         }
-        response = client.patch(f"/company/1/role/{name}", json=data, headers=headers)
+        response = client.patch(
+            f"/company/{company_id}/role/{name}", json=data, headers=headers
+        )
         #
         assert response.status_code == 201
         json_data = response.json()
@@ -37,12 +40,15 @@ def test_b_update_role_description_forbidden(
     """
     Test updating a role's description fails if not admin.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {"Authorization": f"Bearer {login_token_user_two}"}
     payload = {
         "name": None,
         "description": "Should not update",
     }
-    response = client.patch("/company/1/role/Admin", json=payload, headers=headers)
+    response = client.patch(
+        f"/company/{company_id}/role/Admin", json=payload, headers=headers
+    )
     assert response.status_code in [400, 403]
     json_data = response.json()
 
@@ -57,12 +63,15 @@ def test_c_update_role_description_not_found(client, login_token, seed_company_r
     """
     Test updating a role that does not exist
     """
+    company_id = seed_company_roles["company_one"]
     headers = {"Authorization": f"Bearer {login_token}"}
     payload = {
         "name": "Should not update",
         "description": "Should not update",
     }
-    response = client.patch("/company/1/role/string", json=payload, headers=headers)
+    response = client.patch(
+        f"/company/{company_id}/role/string", json=payload, headers=headers
+    )
     assert response.status_code in [400, 403]
     json_data = response.json()
 
@@ -73,5 +82,5 @@ def test_c_update_role_description_not_found(client, login_token, seed_company_r
     )
     assert (
         json_data["detail"]["error"]
-        == "Role with company_id=1 and name='string' not found."
+        == f"Role with company_id={company_id} and name='string' not found."
     )

--- a/tests/api/http/c_company_roles/test_f_delete_role.py
+++ b/tests/api/http/c_company_roles/test_f_delete_role.py
@@ -10,6 +10,7 @@ def test_a_delete_role_success(
     """
     Test deleting a role successfully and reassigning users.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {
         "Authorization": f"Bearer {login_token}",
     }
@@ -20,7 +21,7 @@ def test_a_delete_role_success(
 
     response = client.request(
         method="DELETE",
-        url="/company/1/role",
+        url=f"/company/{company_id}/role",
         json=payload,
         headers=headers,
     )
@@ -40,6 +41,7 @@ def test_b_delete_default_role_forbidden(client, login_token, seed_company_roles
     """
     Test attempting to delete a default system role like 'Administrator'.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {
         "Authorization": f"Bearer {login_token}",
     }
@@ -50,7 +52,7 @@ def test_b_delete_default_role_forbidden(client, login_token, seed_company_roles
 
     response = client.request(
         method="DELETE",
-        url="/company/1/role",
+        url=f"/company/{company_id}/role",
         json=payload,
         headers=headers,
     )
@@ -70,6 +72,7 @@ def test_c_delete_role_not_found(client, login_token, seed_company_roles):
     """
     Test deleting a role that does not exist.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {
         "Authorization": f"Bearer {login_token}",
     }
@@ -80,7 +83,7 @@ def test_c_delete_role_not_found(client, login_token, seed_company_roles):
 
     response = client.request(
         method="DELETE",
-        url="/company/1/role",
+        url=f"/company/{company_id}/role",
         json=payload,
         headers=headers,
     )
@@ -103,6 +106,7 @@ def test_d_delete_role_self_replacement_forbidden(
     """
     Test rejecting deletion where role is being replaced with itself.
     """
+    company_id = seed_company_roles["company_one"]
     headers = {
         "Authorization": f"Bearer {login_token}",
     }
@@ -113,7 +117,7 @@ def test_d_delete_role_self_replacement_forbidden(
 
     response = client.request(
         method="DELETE",
-        url="/company/1/role",
+        url=f"/company/{company_id}/role",
         json=payload,
         headers=headers,
     )

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -2,6 +2,9 @@
 import os
 import json
 import logging
+from datetime import timedelta
+from uuid import UUID
+
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
@@ -18,7 +21,6 @@ from app.models.company.roles import CompanyDefaultRoles
 from app.models.user.user import UserReadModel
 from tests.utils.basic_auth import get_basic_auth_header
 from app.api.security.jwt import JWTManager
-from datetime import timedelta
 
 TEST_DATA_BASE_PATH = "tests/data/http/"
 
@@ -109,7 +111,7 @@ def _get_company_row(email: str):
         session.close()
 
 
-def _get_role_row(company_id: int, name: str):
+def _get_role_row(company_id: UUID, name: str):
     db = DatabaseSessionManager()
     session = db.session_object()
     try:
@@ -122,7 +124,7 @@ def _get_role_row(company_id: int, name: str):
         session.close()
 
 
-def _get_link_row(company_id: int, user_id: int):
+def _get_link_row(company_id: UUID, user_id: UUID):
     db = DatabaseSessionManager()
     session = db.session_object()
     try:
@@ -277,6 +279,10 @@ def seed_companies(client, test_company_data, login_token, login_token_user_two)
     _create_company_if_missing(
         client, login_token_user_two, test_company_data["company_two"]
     )
+    return {
+        "company_one": _get_company_row(test_company_data["company_one"]["email"]).id,
+        "company_two": _get_company_row(test_company_data["company_two"]["email"]).id,
+    }
 
 
 @pytest.fixture(scope="session")
@@ -286,16 +292,17 @@ def seed_company_roles(
     for role_payload in test_company_data["roles"].values():
         _create_role_if_missing(
             client,
-            company_id=1,
+            company_id=seed_companies["company_one"],
             token=login_token,
             role_payload=role_payload,
         )
         _create_role_if_missing(
             client,
-            company_id=2,
+            company_id=seed_companies["company_two"],
             token=login_token_user_two,
             role_payload=role_payload,
         )
+    return seed_companies
 
 
 @pytest.fixture(scope="session")

--- a/tests/api/http/d_company_users/test_h_get_company_users.py
+++ b/tests/api/http/d_company_users/test_h_get_company_users.py
@@ -9,41 +9,47 @@ from app.models.company.response_messages import (
     "login_token_key, company_id, query_params, expected_emails, expected_status",
     [
         # ✅ User 1 accessing own company
-        ("login_token", 1, "limit=10&page=1", {"user.one@email.com"}, 200),
+        ("login_token", "company_one", "limit=10&page=1", {"user.one@email.com"}, 200),
         (
             "login_token",
-            1,
+            "company_one",
             "limit=10&page=1&role_name=Admin",
             set(),
             200,
         ),
         (
             "login_token",
-            1,
+            "company_one",
             "limit=10&page=1&email=user.one@email.com",
             {"user.one@email.com"},
             200,
         ),
         # ❌ User 1 accessing company 2
-        ("login_token", 2, "limit=10&page=1", set(), 403),
+        ("login_token", "company_two", "limit=10&page=1", set(), 403),
         # ✅ User 2 accessing own company
-        ("login_token_user_two", 2, "limit=10&page=1", {"user.two@email.com"}, 200),
         (
             "login_token_user_two",
-            2,
+            "company_two",
+            "limit=10&page=1",
+            {"user.two@email.com"},
+            200,
+        ),
+        (
+            "login_token_user_two",
+            "company_two",
             "limit=10&page=1&first_name=Jane",
             {"user.two@email.com"},
             200,
         ),
         (
             "login_token_user_two",
-            2,
+            "company_two",
             "limit=10&page=1&last_name=Smith",
             {"user.two@email.com"},
             200,
         ),
         # ❌ User 2 accessing company 1
-        ("login_token_user_two", 1, "limit=10&page=1", set(), 403),
+        ("login_token_user_two", "company_one", "limit=10&page=1", set(), 403),
     ],
 )
 def test_get_users_for_company(
@@ -72,6 +78,7 @@ def test_get_users_for_company(
         "Authorization": f"Bearer {token_map[login_token_key]}",
         "accept": "application/json",
     }
+    company_id = seed_companies[company_id]
 
     response = client.get(
         f"/company/{company_id}/users?{query_params}", headers=headers

--- a/tests/api/http/d_company_users/test_i_get_user_companies.py
+++ b/tests/api/http/d_company_users/test_i_get_user_companies.py
@@ -24,10 +24,10 @@ def _set_user_status(email: str, status: str) -> None:
 @pytest.mark.parametrize(
     "login_token_key, query_params, expected_company_ids, expected_status",
     [
-        ("login_token", "limit=10&page=1", {1}, 200),
+        ("login_token", "limit=10&page=1", {"company_one"}, 200),
         ("login_token", "limit=10&page=1&name=Test", set(), 200),  # updated
         ("login_token", "limit=10&page=1&email=notfound@example.com", set(), 200),
-        ("login_token_user_two", "limit=10&page=1", {2}, 200),
+        ("login_token_user_two", "limit=10&page=1", {"company_two"}, 200),
         ("login_token_user_two", "limit=10&page=1&role_name=Admin", set(), 200),
         (
             "login_token_user_two",
@@ -69,6 +69,9 @@ def test_get_user_companies(
         assert (
             json_data["message"] == CompanyUserResponseMessages.GET_COMPANY_USERS.value
         )
+        expected_company_ids = {
+            str(seed_companies[company_id]) for company_id in expected_company_ids
+        }
         company_ids = {company["id"] for company in json_data["data"]["records"]}
         assert company_ids == expected_company_ids
 

--- a/tests/api/http/d_company_users/test_j_add_user_to_company.py
+++ b/tests/api/http/d_company_users/test_j_add_user_to_company.py
@@ -40,14 +40,14 @@ def _create_company(client, token: str) -> int:
         # ✅ Admin adds a new user to company 1 with a valid role
         (
             "login_token",
-            1,
+            "company_one",
             {"email": "user.three@email.com", "role": "Viewer"},
             201,
             CompanyUserResponseMessages.ADD_USER_SUCCESS.value,
         ),
         (
             "login_token_user_two",
-            2,
+            "company_two",
             {"email": "user.three@email.com", "role": "Viewer"},
             201,
             CompanyUserResponseMessages.ADD_USER_SUCCESS.value,
@@ -55,7 +55,7 @@ def _create_company(client, token: str) -> int:
         # ❌ Non-admin tries to add a user to company 1
         (
             "login_token_user_two",
-            1,
+            "company_one",
             {"email": "user.three@email.com", "role": "Viewer"},
             403,
             CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
@@ -63,7 +63,7 @@ def _create_company(client, token: str) -> int:
         # ❌ Admin tries to add a user with an invalid role
         (
             "login_token",
-            1,
+            "company_one",
             {"email": "user.three@email.com", "role": "NotARealRole"},
             400,
             CompanyUserResponseMessages.ADD_USER_FAILED.value,
@@ -71,7 +71,7 @@ def _create_company(client, token: str) -> int:
         # ❌ Admin tries to add a user that does not exist
         (
             "login_token",
-            1,
+            "company_one",
             {"email": "missing.user@email.com", "role": "Viewer"},
             404,
             CompanyUserResponseMessages.ADD_USER_FAILED.value,
@@ -99,6 +99,7 @@ def test_add_user_to_company(
         "login_token": login_token,
         "login_token_user_two": login_token_user_two,
     }
+    company_id = seed_company_roles[company_id]
 
     headers = {
         "Authorization": f"Bearer {token_map[login_token_key]}",

--- a/tests/api/http/d_company_users/test_k_remove_user_from_company.py
+++ b/tests/api/http/d_company_users/test_k_remove_user_from_company.py
@@ -24,7 +24,7 @@ def _build_company_payload() -> dict:
     }
 
 
-def _create_company(client, token: str) -> int:
+def _create_company(client, token: str) -> str:
     response = client.post(
         "/company",
         json=_build_company_payload(),
@@ -35,8 +35,8 @@ def _create_company(client, token: str) -> int:
 
 
 def _add_user_to_company(
-    client, token: str, company_id: int, email: str, role: str = "Viewer"
-) -> int:
+    client, token: str, company_id: str, email: str, role: str = "Viewer"
+) -> str:
     response = client.post(
         f"/company/{company_id}/users",
         json={"email": email, "role": role},
@@ -91,9 +91,15 @@ def test_remove_user_from_company_forbidden_for_non_owner(
 
 def test_remove_owner_from_company_forbidden(client, login_token):
     company_id = _create_company(client, login_token)
+    owner_response = client.get(
+        "/user/get",
+        headers={"Authorization": f"Bearer {login_token}"},
+    )
+    assert owner_response.status_code == 200, owner_response.text
+    owner_id = owner_response.json()["data"]["id"]
 
     response = client.delete(
-        f"/company/{company_id}/user/1",
+        f"/company/{company_id}/user/{owner_id}",
         headers={
             "Authorization": f"Bearer {login_token}",
             "accept": "application/json",

--- a/tests/api/http/d_company_users/test_l_update_user_role.py
+++ b/tests/api/http/d_company_users/test_l_update_user_role.py
@@ -1,4 +1,4 @@
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from app.repository.database.session_manager import DatabaseSessionManager
 from app.repository.database.tables import AssociationUserCompany, User
@@ -22,7 +22,7 @@ def _build_company_payload() -> dict:
     }
 
 
-def _create_company(client, token: str) -> int:
+def _create_company(client, token: str) -> str:
     response = client.post(
         "/company",
         json=_build_company_payload(),
@@ -32,7 +32,7 @@ def _create_company(client, token: str) -> int:
     return response.json()["data"]["id"]
 
 
-def _create_role(client, token: str, company_id: int, payload: dict) -> None:
+def _create_role(client, token: str, company_id: str, payload: dict) -> None:
     response = client.post(
         f"/company/{company_id}/role",
         json=payload,
@@ -41,7 +41,7 @@ def _create_role(client, token: str, company_id: int, payload: dict) -> None:
     assert response.status_code in [200, 201], response.text
 
 
-def _add_user_to_company(client, token: str, company_id: int, email: str) -> int:
+def _add_user_to_company(client, token: str, company_id: str, email: str) -> str:
     response = client.post(
         f"/company/{company_id}/users",
         json={"email": email, "role": "Viewer"},
@@ -51,7 +51,7 @@ def _add_user_to_company(client, token: str, company_id: int, email: str) -> int
     return response.json()["data"]["id"]
 
 
-def _get_user_id(email: str) -> int:
+def _get_user_id(email: str) -> UUID:
     db = DatabaseSessionManager()
     session = db.session_object()
     try:
@@ -61,13 +61,15 @@ def _get_user_id(email: str) -> int:
         session.close()
 
 
-def _get_link_row(company_id: int, user_id: int):
+def _get_link_row(company_id: str, user_id: str):
     db = DatabaseSessionManager()
     session = db.session_object()
     try:
+        company_uuid = UUID(company_id)
+        user_uuid = UUID(user_id)
         return (
             session.query(AssociationUserCompany)
-            .filter_by(company_id=company_id, user_id=user_id, _closed_at=None)
+            .filter_by(company_id=company_uuid, user_id=user_uuid, _closed_at=None)
             .first()
         )
     finally:

--- a/tests/api/http/test_pagination_regressions.py
+++ b/tests/api/http/test_pagination_regressions.py
@@ -70,9 +70,9 @@ def test_get_user_companies_page_two_is_stable(client, seed_pagination_state):
     assert json_data["message"] == CompanyUserResponseMessages.GET_COMPANY_USERS.value
 
     records = json_data["data"]["records"]
-    assert [company["id"] for company in records] == seed_pagination_state[
-        "user_company_ids"
-    ][2:]
+    assert [company["id"] for company in records] == [
+        str(company_id) for company_id in seed_pagination_state["user_company_ids"][2:]
+    ]
 
     pagination = json_data["data"]["pagination"]
     assert pagination == {

--- a/tests/api/security/test_jwt.py
+++ b/tests/api/security/test_jwt.py
@@ -1,9 +1,11 @@
 import asyncio
-import pytest
 from datetime import datetime, timedelta, timezone
+import jwt
+from uuid import uuid4
+
+import pytest
 from fastapi import status
 from fastapi.security import HTTPAuthorizationCredentials
-import jwt
 
 from app.models.user.user import UserReadModel
 from app.models.security_messages import SecurityResponseMessages
@@ -12,7 +14,7 @@ from app.utils.app_error import AppError
 
 # Sample user
 sample_user = UserReadModel(
-    id=1,
+    id=uuid4(),
     first_name="Test",
     last_name="User",
     email="test@example.com",
@@ -50,7 +52,7 @@ def test_decode_refresh_token_invalid_version_defaults_to_zero():
     jwt_manager = JWTManager()
     token = jwt.encode(
         {
-            "user": sample_user.model_dump(),
+            "user": sample_user.model_dump(mode="json"),
             "type": "refresh",
             "refresh_token_version": "invalid",
             "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
@@ -81,7 +83,7 @@ def test_decode_expired_token():
     jwt_manager = JWTManager()
     token = jwt.encode(
         {
-            "user": sample_user.model_dump(),
+            "user": sample_user.model_dump(mode="json"),
             "type": "access",
             "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
         },

--- a/tests/database/test_association_extra.py
+++ b/tests/database/test_association_extra.py
@@ -1,3 +1,5 @@
+from uuid import UUID, uuid4
+
 import pytest
 
 from app.repository.database.tables import AssociationUserCompany
@@ -9,7 +11,7 @@ from app.models.user.user import UserReadModel
 from app.utils.app_error import AppError
 
 
-def _acting_user(*, user_id: int) -> UserReadModel:
+def _acting_user(*, user_id: UUID) -> UserReadModel:
     return UserReadModel(
         id=user_id,
         first_name="Admin",
@@ -64,7 +66,7 @@ def test_link_user_rejects_duplicate_active_link(
         name=test_role_data["admin_role"]["name"],
         description=test_role_data["admin_role"]["description"],
     )
-    acting_user = _acting_user(user_id=999)
+    acting_user = _acting_user(user_id=uuid4())
     AssociationUserCompany.link_user(
         test_session, company["id"], user["id"], role["name"], acting_user
     )
@@ -80,7 +82,7 @@ def test_unlink_user_rejects_missing_link(test_session, test_company_data):
 
     with pytest.raises(AppError, match="User has already been removed"):
         AssociationUserCompany.unlink_user(
-            test_session, company["id"], 1, _acting_user(user_id=999)
+            test_session, company["id"], uuid4(), _acting_user(user_id=uuid4())
         )
 
 
@@ -96,7 +98,11 @@ def test_unlink_user_rejects_self_removal_for_administrator(
         description=test_role_data["admin_role"]["description"],
     )
     AssociationUserCompany.link_user(
-        test_session, company["id"], user["id"], role["name"], _acting_user(user_id=999)
+        test_session,
+        company["id"],
+        user["id"],
+        role["name"],
+        _acting_user(user_id=uuid4()),
     )
 
     with pytest.raises(AppError, match="You cannot remove super admin from company."):

--- a/tests/database/test_base_model_extra.py
+++ b/tests/database/test_base_model_extra.py
@@ -19,7 +19,7 @@ def test_to_dict_handles_none_and_model_lists(test_session, test_user_data):
         first_name="Two",
     )
 
-    records = test_session.query(User).order_by(User.id).all()
+    records = test_session.query(User).order_by(User._created_at, User.email).all()
 
     assert BaseModel.to_dict(None) == {}
     assert BaseModel.to_dict(records)[0]["id"] == user_one["id"]

--- a/tests/database/test_role_extra.py
+++ b/tests/database/test_role_extra.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 
 from app.repository.database.tables import AssociationUserCompany
@@ -10,7 +12,7 @@ from app.utils.app_error import AppError
 
 def _deleted_by_user() -> UserReadModel:
     return UserReadModel(
-        id=99,
+        id=uuid4(),
         first_name="Admin",
         last_name="User",
         email="admin@example.com",
@@ -46,18 +48,20 @@ def test_role_belongs_to_company_raises_when_role_missing(
 
 
 def test_update_role_raises_when_role_missing(test_session):
+    company_id = uuid4()
     with pytest.raises(
-        ValueError, match="Role with company_id=1 and name='Missing' not found."
+        ValueError, match=f"Role with company_id={company_id} and name='Missing' not found."
     ):
-        Role.update_role(test_session, 1, "Missing", new_name="Renamed")
+        Role.update_role(test_session, company_id, "Missing", new_name="Renamed")
 
 
 def test_update_role_json_field_rejects_missing_role(test_session):
+    company_id = uuid4()
     with pytest.raises(
-        ValueError, match="Role with company_id=1 and name='Missing' not found."
+        ValueError, match=f"Role with company_id={company_id} and name='Missing' not found."
     ):
         Role.update_json_field(
-            test_session, 1, "Missing", "primary_meta_data", "key", "value"
+            test_session, company_id, "Missing", "primary_meta_data", "key", "value"
         )
 
 
@@ -98,7 +102,7 @@ def test_update_role_json_field_rejects_non_dict_column(
 def test_delete_role_and_reassign_users_rejects_same_replacement_name(test_session):
     with pytest.raises(ValueError, match="Cannot replace a role with itself."):
         Role.delete_role_and_reassign_users(
-            test_session, 1, "Admin", "Admin", _deleted_by_user()
+            test_session, uuid4(), "Admin", "Admin", _deleted_by_user()
         )
 
 

--- a/tests/utils/test_lightweight_coverage.py
+++ b/tests/utils/test_lightweight_coverage.py
@@ -2,6 +2,7 @@ import importlib
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -367,7 +368,7 @@ def test_verification_service_rejects_non_pending_accounts(monkeypatch):
 
         def get_user_by_email(self, email):
             return UserReadModel(
-                id=1,
+                id=uuid4(),
                 email=email,
                 first_name="Jane",
                 last_name="Doe",
@@ -402,7 +403,7 @@ def test_send_verification_email_logs_dispatch_failures(monkeypatch):
     )
 
     user = UserReadModel(
-        id=1,
+        id=uuid4(),
         email="user@example.com",
         first_name="Jane",
         last_name="Doe",
@@ -426,7 +427,7 @@ def test_company_user_service_sends_company_invite(monkeypatch):
     )
 
     acting_user = UserReadModel(
-        id=99,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -435,7 +436,7 @@ def test_company_user_service_sends_company_invite(monkeypatch):
         is_superuser=False,
     )
     added_user = UserReadModel(
-        id=2,
+        id=uuid4(),
         email="invitee@example.com",
         first_name="Invited",
         last_name="Member",
@@ -446,7 +447,7 @@ def test_company_user_service_sends_company_invite(monkeypatch):
     added_company_user = type(
         "AddedCompanyUser",
         (),
-        {**added_user.model_dump(), "role_name": "Viewer"},
+        {**added_user.model_dump(mode="json"), "role_name": "Viewer"},
     )()
     company = type("Company", (), {"name": "Acme Co"})()
 
@@ -469,7 +470,7 @@ def test_company_user_service_sends_company_invite(monkeypatch):
     )
 
     result = service.add_user_to_company(
-        company_id=1,
+        company_id=uuid4(),
         payload=type(
             "Payload", (), {"email": "invitee@example.com", "role": "Viewer"}
         )(),
@@ -503,7 +504,7 @@ def test_company_user_service_logs_invite_failures(monkeypatch):
     )
 
     acting_user = UserReadModel(
-        id=99,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -537,7 +538,7 @@ def test_company_user_repository_ensure_user_linked_to_company_raises(monkeypatc
     )
 
     with pytest.raises(AppError) as exc_info:
-        repository.ensure_user_linked_to_company(user_id=1, company_id=1)
+        repository.ensure_user_linked_to_company(user_id=uuid4(), company_id=uuid4())
 
     assert (
         exc_info.value.detail["message"]
@@ -557,7 +558,10 @@ def test_company_user_repository_ensure_user_linked_to_company_returns_true(
         lambda user_id, company_id, role_name=None: True,
     )
 
-    assert repository.ensure_user_linked_to_company(user_id=1, company_id=1) is True
+    assert (
+        repository.ensure_user_linked_to_company(user_id=uuid4(), company_id=uuid4())
+        is True
+    )
 
 
 def test_user_repository_get_user_by_id_wraps_unexpected_errors(monkeypatch):
@@ -572,7 +576,7 @@ def test_user_repository_get_user_by_id_wraps_unexpected_errors(monkeypatch):
     monkeypatch.setattr(repository, "_active_user_query", lambda: FailingQuery())
 
     with pytest.raises(AppError) as exc_info:
-        repository.get_user_by_id(1)
+        repository.get_user_by_id(uuid4())
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail["message"] == UserResponseMessages.USER_NOT_FOUND.value
@@ -582,7 +586,7 @@ def test_user_repository_get_user_by_email_rehashes_plaintext_password(monkeypat
     from app.repository.user import UserRepository
 
     class FakeUser:
-        id = 1
+        id = uuid4()
         first_name = "Jane"
         last_name = "Doe"
         email = "user@example.com"
@@ -667,7 +671,7 @@ def test_user_repository_update_user_raises_when_missing(monkeypatch):
     monkeypatch.setattr(repository, "_active_user_query", lambda: FakeQuery())
 
     with pytest.raises(AppError) as exc_info:
-        repository.update_user(1, {"first_name": "Updated"})
+        repository.update_user(uuid4(), {"first_name": "Updated"})
 
     assert exc_info.value.status_code == 400
     assert (
@@ -691,7 +695,7 @@ def test_user_repository_update_user_status_raises_when_missing(monkeypatch):
     monkeypatch.setattr(repository, "_active_user_query", lambda: FakeQuery())
 
     with pytest.raises(AppError) as exc_info:
-        repository.update_user_status(1, UserAccountStatus.ACTIVE.name_value)
+        repository.update_user_status(uuid4(), UserAccountStatus.ACTIVE.name_value)
 
     assert exc_info.value.status_code == 400
     assert (
@@ -717,7 +721,7 @@ def test_user_repository_increment_refresh_token_version_raises_when_missing(
     monkeypatch.setattr(repository, "_active_user_query", lambda: FakeQuery())
 
     with pytest.raises(AppError) as exc_info:
-        repository.increment_refresh_token_version(1)
+        repository.increment_refresh_token_version(uuid4())
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail["message"] == UserResponseMessages.USER_NOT_FOUND.value
@@ -738,7 +742,7 @@ def test_user_repository_delete_user_raises_when_missing(monkeypatch):
     monkeypatch.setattr(repository, "_active_user_query", lambda: FakeQuery())
 
     with pytest.raises(AppError) as exc_info:
-        repository.delete_user(1)
+        repository.delete_user(uuid4())
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail["message"] == UserResponseMessages.USER_NOT_FOUND.value
@@ -746,7 +750,7 @@ def test_user_repository_delete_user_raises_when_missing(monkeypatch):
 
 def test_user_profile_service_get_user_prefers_id(monkeypatch):
     acting_user = UserReadModel(
-        id=9,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -756,7 +760,7 @@ def test_user_profile_service_get_user_prefers_id(monkeypatch):
     )
     service = UserProfileService(SharedContext(db_session=object(), user=acting_user))
     expected = UserReadModel(
-        id=1,
+        id=uuid4(),
         email="target@example.com",
         first_name="Target",
         last_name="User",
@@ -775,14 +779,14 @@ def test_user_profile_service_get_user_prefers_id(monkeypatch):
         ),
     )
 
-    result = service.get_user(user_id=1, user_email="ignored@example.com")
+    result = service.get_user(user_id=expected.id, user_email="ignored@example.com")
 
     assert result == expected
 
 
 def test_user_profile_service_get_user_raises_without_identifier():
     acting_user = UserReadModel(
-        id=9,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -803,7 +807,7 @@ def test_user_profile_service_update_user_handles_phone_and_invalid_request(
     monkeypatch,
 ):
     acting_user = UserReadModel(
-        id=9,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -814,7 +818,7 @@ def test_user_profile_service_update_user_handles_phone_and_invalid_request(
     service = UserProfileService(SharedContext(db_session=object(), user=acting_user))
     captured = {}
     expected = UserReadModel(
-        id=9,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -835,18 +839,18 @@ def test_user_profile_service_update_user_handles_phone_and_invalid_request(
     )
 
     result = service.update_user(
-        9,
+        acting_user.id,
         UserUpdateModel(phone_number="011 222 3333", password="secret"),
     )
 
     assert result == expected
     assert captured == {
-        "user_id": 9,
+        "user_id": acting_user.id,
         "data": {"phone_number": "011 222 3333", "password": "hashed::secret"},
     }
 
     with pytest.raises(AppError) as exc_info:
-        service.update_user(9, UserUpdateModel())
+        service.update_user(acting_user.id, UserUpdateModel())
 
     assert exc_info.value.status_code == 400
     assert (
@@ -857,7 +861,7 @@ def test_user_profile_service_update_user_handles_phone_and_invalid_request(
 
 def test_user_profile_service_get_user_companies_and_delete_user(monkeypatch):
     acting_user = UserReadModel(
-        id=9,
+        id=uuid4(),
         email="admin@example.com",
         first_name="Admin",
         last_name="User",
@@ -886,11 +890,12 @@ def test_user_profile_service_get_user_companies_and_delete_user(monkeypatch):
     )
 
     service.get_user_companies(params)
-    service.delete_user(9)
+    service.delete_user(acting_user.id)
 
-    assert captured["companies"] == (9, params)
-    assert captured["deleted"] == 9
+    assert captured["companies"] == (acting_user.id, params)
+    assert captured["deleted"] == acting_user.id
 
 
 def test_shared_context_safe_json_returns_scalars_unchanged():
     assert SharedContext.safe_json("plain") == "plain"
+from uuid import uuid4

--- a/tests/utils/test_shared_context.py
+++ b/tests/utils/test_shared_context.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
+from uuid import uuid4
 
 import pytest
 
@@ -12,7 +13,7 @@ from app.utils.shared_context import SharedContext
 
 def _build_user(*, status: str = "Active") -> UserReadModel:
     return UserReadModel(
-        id=1,
+        id=uuid4(),
         first_name="Jane",
         last_name="Doe",
         email="jane@example.com",


### PR DESCRIPTION
## Summary

This PR migrates `user.id` and `company.id` from integer primary keys to UUIDs across the schema, application layer, and API surface.

It also fixes Alembic migration bootstrapping so existing local databases can be stamped and upgraded correctly.

## What Changed

- Changed `user.id` and `company.id` from integers to UUIDs
- Updated related foreign keys:
  - `association_user_company.user_id`
  - `association_user_company.company_id`
  - `role.company_id`
- Updated Pydantic models, repositories, services, and route signatures to use UUIDs
- Updated API serialization so UUIDs are returned as strings in JSON responses and JWT payloads
- Added UUID migration:
  - `alembic/versions/4f9d2f8f6c13_migrate_user_and_company_ids_to_uuid.py`
- Reworked `alembic/env.py` to use the current `app.repository.database` path and configured database URL
- Updated pagination ordering to use creation order rather than primary-key order, since UUIDs are not sequential
- Updated tests and fixtures that previously assumed numeric IDs or PK-based ordering

## Why

Integer IDs were exposed throughout the API and were predictable/sequential. UUIDs make identifiers safer for external-facing use and remove reliance on insert-order semantics tied to integer PKs.

## Migration Notes

- Existing databases that already have the pre-UUID schema but no valid Alembic revision stamp should be stamped to the last pre-UUID revision before upgrading:
  - `uv run alembic stamp 9552b9fc884a`
  - `uv run alembic upgrade head`
- SQLite needed migration-specific handling for UUID copy operations, which is included in this PR.

## Testing Notes

Please test assuming numeric IDs are no longer valid.

Focus areas:
- Create, fetch, update, and delete users and companies using returned UUIDs
- Company user flows:
  - add user to company
  - list company users
  - list user companies
  - remove user from company
  - update user role
- Company role endpoints using UUID company IDs
- Alembic upgrade flow on an existing pre-UUID local DB
- Any scripts, fixtures, or clients that still assume `/company/1`-style identifiers

## Verification

- `uv run pytest`
- Result: `285 passed, 1 warning`

## Breaking Change

This is a breaking API and schema change for any consumers that:
- store IDs as integers
- send numeric `company_id` or `user_id` values
- depend on primary-key ordering being sequential or numeric