### PR TITLE
Invalidate old access_tokens

### DIFF
--- a/app/api/security/jwt.py
+++ b/app/api/security/jwt.py
@@ -47,6 +47,7 @@ class JWTManager:
         access_payload = {
             "user": user.model_dump(mode="json"),
             "type": "access",
+            "refresh_token_version": refresh_token_version,
             "exp": access_expire,
         }
 
@@ -157,6 +158,16 @@ class JWTManager:
         decoded = self._decode_token_payload(token, expected_type="access")
         return UserReadModel(**decoded["user"])
 
+    def decode_access_token(self, token: str) -> tuple[UserReadModel, int]:
+        decoded = self._decode_token_payload(token, expected_type="access")
+        refresh_token_version = decoded.get("refresh_token_version", 0)
+        try:
+            normalized_version = int(refresh_token_version)
+        except (TypeError, ValueError):
+            normalized_version = 0
+
+        return UserReadModel(**decoded["user"]), normalized_version
+
     def decode_refresh_token(self, token: str) -> tuple[UserReadModel, int]:
         decoded = self._decode_token_payload(token, expected_type="refresh")
         refresh_token_version = decoded.get("refresh_token_version", 0)
@@ -202,8 +213,16 @@ async def get_current_user_from_jwt_token(
         )
 
     try:
-        token_user = JWTManager().decode_token(authorization)
-        current_user = UserRepository(session).get_user_by_id(token_user.id)
+        jwt_manager = JWTManager()
+        user_repository = UserRepository(session)
+        token_user, token_version = jwt_manager.decode_access_token(authorization)
+        current_user = user_repository.get_user_by_id(token_user.id)
+        current_version = user_repository.get_refresh_token_version(current_user.id)
+        if token_version != current_version:
+            raise AppError(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                message=SecurityResponseMessages.INVALID_TOKEN.value,
+            )
         if not _status_allowed_for_authenticated_access(current_user.status):
             raise AppError(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/app/services/user/basic_auth.py
+++ b/app/services/user/basic_auth.py
@@ -114,7 +114,9 @@ class UserBasicAuthService:
         )
         self._resend_verification_email_for_pending_login(user)
         self._ensure_user_is_active(user)
-        refresh_token_version = self.user_repository.get_refresh_token_version(user.id)
+        refresh_token_version = self.user_repository.increment_refresh_token_version(
+            user.id
+        )
         return JWTManager().sign_jwt(user, refresh_token_version=refresh_token_version)
 
     def refresh_user_token(self, refresh_token: str) -> TokenResponseModel:

--- a/tests/api/http/a_user/test_b_user_login_api.py
+++ b/tests/api/http/a_user/test_b_user_login_api.py
@@ -192,6 +192,38 @@ async def test_user_revoke_blocks_old_refresh_token(client, test_user_data, seed
     assert refresh_response.status_code == 401
 
 
+async def test_second_login_invalidates_first_login_tokens(
+    client, test_user_data, seed_verified_users
+):
+    user_one = test_user_data["user_one"]
+    first_login = await _login_for_tokens(client, user_one)
+    second_login = await _login_for_tokens(client, user_one)
+
+    old_access_response = await client.get(
+        "/user/get",
+        headers={"Authorization": f"Bearer {first_login['access_token']}"},
+    )
+    assert old_access_response.status_code == 401
+
+    old_refresh_response = await client.post(
+        "/user/refresh",
+        json={"refresh_token": first_login["refresh_token"]},
+    )
+    assert old_refresh_response.status_code == 401
+
+    latest_access_response = await client.get(
+        "/user/get",
+        headers={"Authorization": f"Bearer {second_login['access_token']}"},
+    )
+    assert latest_access_response.status_code == 200
+
+    latest_refresh_response = await client.post(
+        "/user/refresh",
+        json={"refresh_token": second_login["refresh_token"]},
+    )
+    assert latest_refresh_response.status_code == 202
+
+
 async def test_user_refresh_rejects_inactive_user(
     client, test_user_data, seed_verified_users
 ):

--- a/tests/api/security/test_jwt.py
+++ b/tests/api/security/test_jwt.py
@@ -39,6 +39,15 @@ def test_decode_valid_access_token():
     assert user.email == sample_user.email
 
 
+def test_decode_valid_access_token_returns_version():
+    jwt_manager = JWTManager()
+    tokens = jwt_manager.sign_jwt(sample_user, refresh_token_version=7)
+    user, refresh_token_version = jwt_manager.decode_access_token(tokens.access_token)
+
+    assert user.email == sample_user.email
+    assert refresh_token_version == 7
+
+
 def test_decode_valid_refresh_token():
     jwt_manager = JWTManager()
     tokens = jwt_manager.sign_jwt(sample_user, refresh_token_version=3)
@@ -226,12 +235,16 @@ def test_get_current_user_from_jwt_token_rejects_missing_credentials():
 
 def test_get_current_user_from_jwt_token_returns_decoded_user(monkeypatch):
     monkeypatch.setattr(
-        "app.api.security.jwt.JWTManager.decode_token",
-        lambda self, token: sample_user,
+        "app.api.security.jwt.JWTManager.decode_access_token",
+        lambda self, token: (sample_user, 2),
     )
     monkeypatch.setattr(
         "app.api.security.jwt.UserRepository.get_user_by_id",
         lambda self, user_id: sample_user.model_copy(update={"status": "Active"}),
+    )
+    monkeypatch.setattr(
+        "app.api.security.jwt.UserRepository.get_refresh_token_version",
+        lambda self, user_id: 2,
     )
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer", credentials="signed-token"
@@ -254,7 +267,7 @@ def test_get_current_user_from_jwt_token_reraises_app_error(monkeypatch):
     def _raise(self, token):
         raise expected_error
 
-    monkeypatch.setattr("app.api.security.jwt.JWTManager.decode_token", _raise)
+    monkeypatch.setattr("app.api.security.jwt.JWTManager.decode_access_token", _raise)
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer", credentials="signed-token"
     )
@@ -271,7 +284,7 @@ def test_get_current_user_from_jwt_token_wraps_unexpected_error(monkeypatch):
     def _raise(self, token):
         raise RuntimeError("decode failed")
 
-    monkeypatch.setattr("app.api.security.jwt.JWTManager.decode_token", _raise)
+    monkeypatch.setattr("app.api.security.jwt.JWTManager.decode_access_token", _raise)
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer", credentials="signed-token"
     )
@@ -288,13 +301,17 @@ def test_get_current_user_from_jwt_token_wraps_unexpected_error(monkeypatch):
 
 def test_get_current_user_from_jwt_token_rejects_inactive_database_user(monkeypatch):
     monkeypatch.setattr(
-        "app.api.security.jwt.JWTManager.decode_token",
-        lambda self, token: sample_user,
+        "app.api.security.jwt.JWTManager.decode_access_token",
+        lambda self, token: (sample_user, 3),
     )
     inactive_user = sample_user.model_copy(update={"status": "Suspended"})
     monkeypatch.setattr(
         "app.api.security.jwt.UserRepository.get_user_by_id",
         lambda self, user_id: inactive_user,
+    )
+    monkeypatch.setattr(
+        "app.api.security.jwt.UserRepository.get_refresh_token_version",
+        lambda self, user_id: 3,
     )
     credentials = HTTPAuthorizationCredentials(
         scheme="Bearer", credentials="signed-token"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -538,6 +538,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -548,6 +549,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -558,6 +560,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1880,7 +1883,7 @@ wheels = [
 
 [[package]]
 name = "userverse"
-version = "0.6.32"
+version = "0.6.33"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Invalidate previously issued tokens when a user logs in again.

## What Changed

- Increment `refresh_token_version` on successful login
- Include `refresh_token_version` in access token payloads
- Decode access tokens with their token version
- Reject authenticated requests when the access token version no longer matches the user’s current token version
- Add coverage for stale-token invalidation across both access and refresh tokens

## Why

Previously, a new login could leave older issued tokens valid. This change ensures a new login invalidates tokens from earlier sessions.

## Testing

- Added login flow coverage to confirm a second login invalidates the first login’s access and refresh tokens
- Added JWT coverage to confirm access token version decoding and current-version enforcement

## Notes

- `uv.lock` changed and includes a version bump to `0.6.33`