### PR TITLE
`Refactor roles to be shared across companies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Business logic lives in `app/services`. Services coordinate authorization checks
 
 ### Repository and Database Layer
 
-Repository classes live in `app/repository`. SQLAlchemy models and session management live under `app/repository/database`. The canonical tables are `User`, `Company`, `Role`, and `AssociationUserCompany`.
+Repository classes live in `app/repository`. SQLAlchemy models and session management live under `app/repository/database`. The canonical tables are `User`, `Company`, `Role`, `CompanyRole`, and `AssociationUserCompany`.
+
+Roles are modeled as a shared global catalog. Company membership in a role is represented by `company_role`, and user assignments point at the shared role record through `association_user_company.role_id`.
 
 ### Configuration
 
@@ -162,6 +164,8 @@ Apply migrations with Alembic:
 ```bash
 uv run alembic upgrade head
 ```
+
+If you have an older local SQLite database from before the shared-role catalog change, run migrations before starting the app. Current startup checks reject partial or incompatible schemas instead of silently mixing old `role` layouts with the new `company_role` model.
 
 Create a new migration after changing SQLAlchemy table models:
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ uv run pytest tests/api/http -q --http-env-file /home/sandile/projects/pj-userve
 
 Use the env-backed mode carefully: it does not create an isolated temporary database, and the HTTP test fixtures may update or seed the target database.
 
-Coverage is generated with `pytest-cov` and written to `coverage_reports/coverage.xml`. The current CI threshold is `95%`.
+Coverage is generated with `pytest-cov` and written to `coverage_reports/coverage.xml`. The current CI threshold is `96%`.
 
 See [tests/README.md](tests/README.md) and [docs/testing.md](docs/testing.md) for more detail.
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,20 @@ Run selected suites:
 
 ```bash
 uv run pytest tests/api/http
+uv run pytest tests/api/http --http-env-file .env
 uv run pytest tests/api/security
 uv run pytest tests/database
 uv run pytest tests/utils
 ```
+
+By default, `tests/api/http` uses an isolated temporary SQLite database and test-safe overrides. If you want to seed or validate a real environment-backed database, pass `--http-env-file` with a dotenv file that defines at least `DATABASE_URL`:
+
+```bash
+uv run pytest tests/api/http/c_company_roles -q --http-env-file .env
+uv run pytest tests/api/http -q --http-env-file /home/sandile/projects/pj-userverse/userverse/.env
+```
+
+Use the env-backed mode carefully: it does not create an isolated temporary database, and the HTTP test fixtures may update or seed the target database.
 
 Coverage is generated with `pytest-cov` and written to `coverage_reports/coverage.xml`. The current CI threshold is `95%`.
 

--- a/alembic/versions/a4e8c1b7d2f9_normalize_roles_to_global_catalog.py
+++ b/alembic/versions/a4e8c1b7d2f9_normalize_roles_to_global_catalog.py
@@ -1,0 +1,194 @@
+"""Normalize roles to a global catalog shared across companies.
+
+Revision ID: a4e8c1b7d2f9
+Revises: 4f9d2f8f6c13
+Create Date: 2026-08-03 18:45:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+from uuid import uuid4
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a4e8c1b7d2f9"
+down_revision: Union[str, None] = "4f9d2f8f6c13"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ROLE_TEMP = "role_global_tmp"
+COMPANY_ROLE_TEMP = "company_role_tmp"
+ASSOCIATION_TEMP = "association_user_company_tmp"
+
+
+def _reflect_table(connection, table_name: str) -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(table_name, metadata, autoload_with=connection)
+
+
+def _has_column(connection, table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(connection)
+    return any(
+        column["name"] == column_name for column in inspector.get_columns(table_name)
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    connection = op.get_bind()
+
+    if _has_column(connection, "role", "id") and not _has_column(
+        connection, "role", "company_id"
+    ):
+        return
+
+    op.create_table(
+        ROLE_TEMP,
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("description", sa.String(length=256), nullable=True),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_table(
+        COMPANY_ROLE_TEMP,
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["company_id"], ["company.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["role_id"], [f"{ROLE_TEMP}.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("company_id", "role_id"),
+        sa.UniqueConstraint("company_id", "role_id", name="uq_company_role"),
+    )
+    op.create_table(
+        ASSOCIATION_TEMP,
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=True),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["company_id"], ["company.id"]),
+        sa.ForeignKeyConstraint(["role_id"], [f"{ROLE_TEMP}.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "company_id"),
+    )
+
+    role_table = _reflect_table(connection, "role")
+    association_table = _reflect_table(connection, "association_user_company")
+
+    role_target = _reflect_table(connection, ROLE_TEMP)
+    company_role_target = _reflect_table(connection, COMPANY_ROLE_TEMP)
+    association_target = _reflect_table(connection, ASSOCIATION_TEMP)
+
+    role_rows = connection.execute(sa.select(role_table)).mappings().all()
+    association_rows = connection.execute(sa.select(association_table)).mappings().all()
+
+    global_role_ids: dict[str, str] = {}
+    role_descriptions: dict[str, str | None] = {}
+    role_key_map: dict[tuple[str, str], str] = {}
+
+    for row in role_rows:
+        role_name = row["name"]
+        company_id = str(row["company_id"])
+        role_id = global_role_ids.get(role_name)
+        if role_id is None:
+            role_id = str(uuid4())
+            global_role_ids[role_name] = role_id
+            role_descriptions[role_name] = row.get("description")
+            connection.execute(
+                sa.insert(role_target).values(
+                    id=role_id,
+                    name=role_name,
+                    description=row.get("description"),
+                    _created_at=row.get("_created_at"),
+                    _updated_at=row.get("_updated_at"),
+                    _closed_at=row.get("_closed_at"),
+                    primary_meta_data=row.get("primary_meta_data"),
+                    secondary_meta_data=row.get("secondary_meta_data"),
+                )
+            )
+        elif role_descriptions[role_name] is None and row.get("description") is not None:
+            role_descriptions[role_name] = row.get("description")
+            connection.execute(
+                sa.update(role_target)
+                .where(role_target.c.id == role_id)
+                .values(description=row.get("description"))
+            )
+
+        role_key_map[(company_id, role_name)] = role_id
+        connection.execute(
+            sa.insert(company_role_target).values(
+                company_id=row["company_id"],
+                role_id=role_id,
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=row.get("secondary_meta_data"),
+            )
+        )
+
+    for row in association_rows:
+        role_id = role_key_map[(str(row["company_id"]), row["role_name"])]
+        secondary_meta_data = row.get("secondary_meta_data") or {}
+        secondary_meta_data["_legacy_role_name"] = row["role_name"]
+        connection.execute(
+            sa.insert(association_target).values(
+                user_id=row["user_id"],
+                company_id=row["company_id"],
+                role_id=role_id,
+                _created_at=row.get("_created_at"),
+                _updated_at=row.get("_updated_at"),
+                _closed_at=row.get("_closed_at"),
+                primary_meta_data=row.get("primary_meta_data"),
+                secondary_meta_data=secondary_meta_data,
+            )
+        )
+
+    op.drop_table("association_user_company")
+    if _has_column(connection, "company_role", "role_id"):
+        op.drop_table("company_role")
+    op.drop_table("role")
+
+    op.rename_table(ROLE_TEMP, "role")
+    op.rename_table(COMPANY_ROLE_TEMP, "company_role")
+    op.rename_table(ASSOCIATION_TEMP, "association_user_company")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise NotImplementedError(
+        "Downgrade is not supported for the role catalog normalization migration."
+    )

--- a/app/api/routers/company/roles.py
+++ b/app/api/routers/company/roles.py
@@ -1,11 +1,11 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status, Path
+from fastapi import APIRouter, Depends, Path, status
 from fastapi.responses import JSONResponse
 
-# Models
-from app.models.generic_pagination import PaginatedResponse
-from app.models.generic_response import GenericResponseModel
+from app.api.dependencies.common import CommonJWTRouteDependencies
+from app.models.app_error import AppErrorResponseModel
+from app.models.company.response_messages import CompanyRoleResponseMessages
 from app.models.company.roles import (
     RoleCreateModel,
     RoleDeleteModel,
@@ -13,21 +13,11 @@ from app.models.company.roles import (
     RoleReadModel,
     RoleUpdateModel,
 )
-from app.models.app_error import AppErrorResponseModel
-from app.models.company.response_messages import (
-    CompanyRoleResponseMessages,
-)
-
-# Auth
+from app.models.generic_pagination import PaginatedResponse
+from app.models.generic_response import GenericResponseModel
 from app.models.tags import UserverseApiTag
-from app.api.dependencies.common import CommonJWTRouteDependencies
-
-# Business Logic
 from app.services.company.role import RoleService
 from app.utils.shared_context import SharedContext
-
-# Utilities
-from app.utils.app_error import AppError
 
 router = APIRouter()
 tag = UserverseApiTag.COMPANY_ROLE_MANAGEMENT.name
@@ -48,26 +38,15 @@ def create_role_api(
     company_id: UUID = Path(..., description="The unique identifier of the company"),
     common: CommonJWTRouteDependencies = Depends(),
 ):
-    """
-    Create a new role for the specified company.
-
-    - **Requires**: Authenticated user
-    - **Returns**: The created role
-    """
-    try:
-        service = RoleService(
-            SharedContext(user=common.user, db_session=common.session)
-        )
-        response = service.create_role(payload=payload, company_id=company_id)
-        return JSONResponse(
-            status_code=status.HTTP_201_CREATED,
-            content={
-                "message": CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
-                "data": response.model_dump(mode="json"),
-            },
-        )
-    except (AppError, Exception) as e:
-        raise e
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.create_role_for_company(payload=payload, company_id=company_id)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={
+            "message": CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
+            "data": response.model_dump(mode="json"),
+        },
+    )
 
 
 @router.patch(
@@ -75,7 +54,7 @@ def create_role_api(
     tags=[tag],
     status_code=status.HTTP_200_OK,
     responses={
-        201: {"model": GenericResponseModel[RoleReadModel]},
+        200: {"model": GenericResponseModel[RoleReadModel]},
         400: {"model": AppErrorResponseModel},
         404: {"model": AppErrorResponseModel},
         500: {"model": AppErrorResponseModel},
@@ -83,32 +62,23 @@ def create_role_api(
 )
 def update_role_api(
     payload: RoleUpdateModel,
-    company_id: UUID = Path(..., description="The company ID associated with the role"),
-    name: str = Path(..., description="The name of the role to update"),
+    company_id: UUID,
+    name: str,
     common: CommonJWTRouteDependencies = Depends(),
 ):
-    """
-    Update a role's description by its name.
-
-    - **Requires**: Authenticated user
-    - **Returns**: Updated role data
-    """
-    try:
-        service = RoleService(
-            SharedContext(user=common.user, db_session=common.session)
-        )
-        response = service.update_role(
-            company_id=company_id, name=name, payload=payload
-        )
-        return JSONResponse(
-            status_code=status.HTTP_201_CREATED,
-            content={
-                "message": CompanyRoleResponseMessages.ROLE_UPDATED.value,
-                "data": response.model_dump(mode="json"),
-            },
-        )
-    except (AppError, Exception) as e:
-        raise e
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.update_company_role(
+        company_id=company_id,
+        name=name,
+        payload=payload,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={
+            "message": CompanyRoleResponseMessages.ROLE_UPDATED.value,
+            "data": response.model_dump(mode="json"),
+        },
+    )
 
 
 @router.delete(
@@ -116,7 +86,7 @@ def update_role_api(
     tags=[tag],
     status_code=status.HTTP_200_OK,
     responses={
-        201: {"model": GenericResponseModel[dict]},
+        200: {"model": GenericResponseModel[dict]},
         400: {"model": AppErrorResponseModel},
         404: {"model": AppErrorResponseModel},
         500: {"model": AppErrorResponseModel},
@@ -127,26 +97,15 @@ def delete_role_api(
     company_id: UUID = Path(..., description="Company ID to delete role from"),
     common: CommonJWTRouteDependencies = Depends(),
 ):
-    """
-    Delete a role from a company and reassign affected users to a replacement role.
-
-    - **Requires**: Authenticated user
-    - **Returns**: Success message with result info
-    """
-    try:
-        service = RoleService(
-            SharedContext(user=common.user, db_session=common.session)
-        )
-        response = service.delete_role(payload=payload, company_id=company_id)
-        return JSONResponse(
-            status_code=status.HTTP_201_CREATED,
-            content={
-                "message": CompanyRoleResponseMessages.ROLE_DELETED.value,
-                "data": response,
-            },
-        )
-    except (AppError, Exception) as e:
-        raise e
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.delete_role(payload=payload, company_id=company_id)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={
+            "message": CompanyRoleResponseMessages.ROLE_DELETED.value,
+            "data": response,
+        },
+    )
 
 
 @router.get(
@@ -164,25 +123,66 @@ def get_company_roles_api(
     query_params: RoleQueryParamsModel = Depends(),
     common: CommonJWTRouteDependencies = Depends(),
 ):
-    """
-    Get a paginated list of all roles associated with a specific company.
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.get_company_roles(
+        payload=query_params, company_id=company_id
+    )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value,
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
 
-    - **Supports**: Filtering, pagination
-    - **Requires**: Authenticated user
-    """
-    try:
-        service = RoleService(
-            SharedContext(user=common.user, db_session=common.session)
-        )
-        response = service.get_company_roles(
-            payload=query_params, company_id=company_id
-        )
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content=GenericResponseModel(
-                message=CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value,
-                data=response.model_dump(mode="json"),
-            ).model_dump(mode="json"),
-        )
-    except (AppError, Exception) as e:
-        raise e
+
+@router.post(
+    "/company/{company_id}/roles/{role_id}",
+    tags=[tag],
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        201: {"model": GenericResponseModel[RoleReadModel]},
+        400: {"model": AppErrorResponseModel},
+        500: {"model": AppErrorResponseModel},
+    },
+)
+def assign_role_to_company_api(
+    company_id: UUID,
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.assign_role_to_company(company_id=company_id, role_id=role_id)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/company/{company_id}/roles/{role_id}",
+    tags=[tag],
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"model": GenericResponseModel[dict]},
+        400: {"model": AppErrorResponseModel},
+        500: {"model": AppErrorResponseModel},
+    },
+)
+def unassign_role_from_company_api(
+    company_id: UUID,
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.unassign_role(company_id=company_id, role_id=role_id)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_DELETED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )

--- a/app/api/routers/roles.py
+++ b/app/api/routers/roles.py
@@ -1,0 +1,113 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from app.api.dependencies.common import CommonJWTRouteDependencies
+from app.models.app_error import AppErrorResponseModel
+from app.models.company.response_messages import CompanyRoleResponseMessages
+from app.models.company.roles import (
+    RoleAssignCompaniesModel,
+    RoleCreateModel,
+    RoleQueryParamsModel,
+    RoleReadModel,
+    RoleUpdateModel,
+)
+from app.models.generic_pagination import PaginatedResponse
+from app.models.generic_response import GenericResponseModel
+from app.models.tags import UserverseApiTag
+from app.services.company.role import RoleService
+from app.utils.shared_context import SharedContext
+
+router = APIRouter()
+tag = UserverseApiTag.COMPANY_ROLE_MANAGEMENT.name
+
+
+@router.post("/roles", tags=[tag], status_code=status.HTTP_201_CREATED)
+def create_role_api(
+    payload: RoleCreateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.create_role(payload)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/roles",
+    tags=[tag],
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"model": GenericResponseModel[PaginatedResponse[RoleReadModel]]},
+        400: {"model": AppErrorResponseModel},
+    },
+)
+def get_roles_api(
+    query_params: RoleQueryParamsModel = Depends(),
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.get_roles(payload=query_params)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_GET_SUCCESS.value,
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
+
+
+@router.patch("/roles/{role_id}", tags=[tag], status_code=status.HTTP_200_OK)
+def update_role_api(
+    role_id: UUID,
+    payload: RoleUpdateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.update_role(role_id=role_id, payload=payload)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_UPDATED.value,
+            data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete("/roles/{role_id}", tags=[tag], status_code=status.HTTP_200_OK)
+def delete_role_api(
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.delete_global_role(role_id=role_id)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_DELETED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.post("/roles/{role_id}/companies", tags=[tag], status_code=status.HTTP_201_CREATED)
+def assign_role_to_companies_api(
+    role_id: UUID,
+    payload: RoleAssignCompaniesModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = RoleService(SharedContext(user=common.user, db_session=common.session))
+    response = service.assign_role_to_companies(role_id=role_id, payload=payload)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.api.routers.company import (
     users,
     roles,
 )
+from app.api.routers import roles as global_roles
 
 # utils
 from app.configs import settings
@@ -89,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(company.router)
     app.include_router(users.router)
     app.include_router(roles.router)
+    app.include_router(global_roles.router)
 
     # Root route
     @app.get("/", tags=["Root"])

--- a/app/models/company/roles.py
+++ b/app/models/company/roles.py
@@ -45,8 +45,13 @@ class RoleDeleteModel(BaseModel):
 
 
 class RoleReadModel(BaseModel):
+    id: str | None = None
     name: Optional[str]
     description: Optional[str]
+
+
+class RoleAssignCompaniesModel(BaseModel):
+    company_ids: list[str]
 
 
 class RoleQueryParamsModel(PaginationParams):

--- a/app/models/company/user.py
+++ b/app/models/company/user.py
@@ -4,6 +4,7 @@ from app.models.user.user import UserReadModel
 
 
 class CompanyUserReadModel(UserReadModel):
+    role_id: str | None = None
     role_name: str
 
 

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -20,7 +20,12 @@ from app.models.generic_pagination import (
 )
 from app.repository.base import BaseSQLRepository
 from app.repository.company_user import CompanyUserRepository
-from app.repository.database.tables import AssociationUserCompany, Company, Role
+from app.repository.database.tables import (
+    AssociationUserCompany,
+    Company,
+    CompanyRole,
+    Role,
+)
 from app.utils.app_error import AppError
 
 
@@ -52,6 +57,30 @@ class CompanyRepository(BaseSQLRepository[Company]):
             .one_or_none()
         )
 
+    def _ensure_default_roles(self) -> dict[str, Role]:
+        default_roles: dict[str, Role] = {}
+        for default_role in CompanyDefaultRoles:
+            role = (
+                self.db_session.query(Role)
+                .filter(
+                    Role.name == default_role.name_value,
+                    Role._closed_at.is_(None),
+                )
+                .one_or_none()
+            )
+            if role is None:
+                role = Role(
+                    name=default_role.name_value,
+                    description=default_role.description,
+                )
+                self.db_session.add(role)
+                self.db_session.flush()
+            elif role.description != default_role.description:
+                role.description = default_role.description
+            default_roles[default_role.name_value] = role
+        self.db_session.commit()
+        return default_roles
+
     def create_company(
         self, payload: CompanyCreateModel, created_by
     ) -> CompanyReadModel:
@@ -79,14 +108,9 @@ class CompanyRepository(BaseSQLRepository[Company]):
                 value=payload.address.model_dump(),
             )
 
-        for role in CompanyDefaultRoles:
-            self.db_session.add(
-                Role(
-                    company_id=company.id,
-                    name=role.name_value,
-                    description=role.description,
-                )
-            )
+        default_roles = self._ensure_default_roles()
+        for role in default_roles.values():
+            self.db_session.add(CompanyRole(company_id=company.id, role_id=role.id))
         self.db_session.commit()
 
         CompanyUserRepository(self.db_session).add_user_to_company(
@@ -160,6 +184,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
         query = (
             self.db_session.query(AssociationUserCompany)
             .join(AssociationUserCompany.company)
+            .join(AssociationUserCompany.role)
             .filter(
                 AssociationUserCompany.user_id == user_id,
                 AssociationUserCompany._closed_at.is_(None),
@@ -167,9 +192,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
             )
         )
         if params.role_name:
-            query = query.filter(
-                AssociationUserCompany.role_name.ilike(f"%{params.role_name}%")
-            )
+            query = query.filter(Role.name.ilike(f"%{params.role_name}%"))
         if params.name:
             query = query.filter(Company.name.ilike(f"%{params.name}%"))
         if params.description:

--- a/app/repository/company_role.py
+++ b/app/repository/company_role.py
@@ -25,6 +25,19 @@ from app.utils.app_error import AppError
 class RoleRepository(BaseSQLRepository[Role]):
     model = Role
 
+    def __init__(
+        self,
+        db_session: Session | None = None,
+        *,
+        company_id: UUID | None = None,
+        session: Session | None = None,
+    ):
+        resolved_session = db_session if db_session is not None else session
+        if resolved_session is None:
+            raise TypeError("RoleRepository requires a database session.")
+        super().__init__(resolved_session)
+        self.company_id = company_id
+
     @staticmethod
     def _to_read_model(role: Role) -> RoleReadModel:
         data = BaseSQLRepository.serialize(role)
@@ -84,6 +97,21 @@ class RoleRepository(BaseSQLRepository[Role]):
             )
         return role
 
+    def ensure_role_belongs_to_company(self, role_name: str) -> Role:
+        if self.company_id is None:
+            return self.ensure_role_by_name(role_name)
+        role = CompanyRoleAssignmentRepository(
+            company_id=self.company_id,
+            session=self.db_session,
+        ).get_role_name_assigned(role_name)
+        if not isinstance(role, Role):
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyUserResponseMessages.ADD_USER_FAILED.value,
+                error=f"Role: {role_name} is not linked to the company",
+            )
+        return role
+
     def create_role(
         self, payload: RoleCreateModel, created_by: UserReadModel
     ) -> RoleReadModel:
@@ -115,8 +143,18 @@ class RoleRepository(BaseSQLRepository[Role]):
 
     def update_role(self, role_id: UUID, payload: RoleUpdateModel) -> RoleReadModel:
         try:
-            role = self.get_role_record(role_id)
+            if self.company_id is not None and isinstance(role_id, str):
+                role = CompanyRoleAssignmentRepository(
+                    company_id=self.company_id,
+                    session=self.db_session,
+                ).get_role_name_assigned(role_id)
+            else:
+                role = self.get_role_record(role_id)
             if not role:
+                if self.company_id is not None and isinstance(role_id, str):
+                    raise ValueError(
+                        f"Role with company_id={self.company_id} and name='{role_id}' not found."
+                    )
                 raise ValueError(f"Role with id='{role_id}' not found.")
             if payload.name:
                 role.name = payload.name
@@ -133,8 +171,44 @@ class RoleRepository(BaseSQLRepository[Role]):
                 error=str(exc),
             ) from exc
 
-    def delete_role(self, role_id: UUID, deleted_by: UserReadModel) -> dict:
+    def delete_role(
+        self,
+        role_id: UUID | None = None,
+        deleted_by: UserReadModel | None = None,
+        payload: RoleDeleteModel | None = None,
+    ) -> dict:
+        if payload is not None:
+            if self.company_id is None:
+                raise AppError(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                    error="company_id is required for company-scoped role deletion.",
+                )
+            if deleted_by is None:
+                raise AppError(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                    error="deleted_by is required for role deletion.",
+                )
+            try:
+                return Role.delete_role_and_reassign_users(
+                    session=self.db_session,
+                    company_id=self.company_id,
+                    name_to_delete=payload.role_name_to_delete,
+                    replacement_name=payload.replacement_role_name,
+                    deleted_by=deleted_by,
+                )
+            except Exception as exc:
+                self.db_session.rollback()
+                raise AppError(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                    error=str(exc),
+                ) from exc
+
         try:
+            if role_id is None or deleted_by is None:
+                raise ValueError("role_id and deleted_by are required.")
             role = self.get_role_record(role_id)
             if not role:
                 raise ValueError(f"Role with id='{role_id}' not found.")

--- a/app/repository/company_role.py
+++ b/app/repository/company_role.py
@@ -1,12 +1,15 @@
 from uuid import UUID
 
 from fastapi import status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from app.models.company.response_messages import (
     CompanyRoleResponseMessages,
     CompanyUserResponseMessages,
 )
 from app.models.company.roles import (
+    RoleAssignCompaniesModel,
     RoleCreateModel,
     RoleDeleteModel,
     RoleQueryParamsModel,
@@ -15,28 +18,22 @@ from app.models.company.roles import (
 )
 from app.models.user.user import UserReadModel
 from app.repository.base import BaseSQLRepository
-from app.repository.database.tables import Role
+from app.repository.database.tables import AssociationUserCompany, CompanyRole, Role
 from app.utils.app_error import AppError
 
 
 class RoleRepository(BaseSQLRepository[Role]):
     model = Role
 
-    def __init__(self, company_id: UUID, session):
-        super().__init__(session)
-        self.company_id = company_id
-
     @staticmethod
     def _to_read_model(role: Role) -> RoleReadModel:
         data = BaseSQLRepository.serialize(role)
+        data["id"] = str(role.id)
         return RoleReadModel(**data)
 
     def get_roles(self, payload: RoleQueryParamsModel) -> dict:
         try:
-            query = self._base_query().filter(
-                Role.company_id == self.company_id,
-                Role._closed_at.is_(None),
-            )
+            query = self._base_query().filter(Role._closed_at.is_(None))
             if payload.name:
                 query = query.filter(Role.name.ilike(f"%{payload.name}%"))
             if payload.description:
@@ -54,19 +51,31 @@ class RoleRepository(BaseSQLRepository[Role]):
                 error=str(exc),
             ) from exc
 
-    def get_role_record(self, role_name: str) -> Role | None:
+    def get_role_record(self, role_id: UUID) -> Role | None:
         return (
             self._base_query()
-            .filter(
-                Role.company_id == self.company_id,
-                Role.name == role_name,
-                Role._closed_at.is_(None),
-            )
+            .filter(Role.id == role_id, Role._closed_at.is_(None))
             .one_or_none()
         )
 
-    def ensure_role_belongs_to_company(self, role_name: str) -> Role:
-        role = self.get_role_record(role_name)
+    def get_role_by_name(self, role_name: str) -> Role | None:
+        return (
+            self._base_query()
+            .filter(Role.name == role_name, Role._closed_at.is_(None))
+            .one_or_none()
+        )
+
+    def ensure_role_exists(self, role_id: UUID) -> Role:
+        role = self.get_role_record(role_id)
+        if not role:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=CompanyRoleResponseMessages.ROLE_NOT_FOUND.value,
+            )
+        return role
+
+    def ensure_role_by_name(self, role_name: str) -> Role:
+        role = self.get_role_by_name(role_name)
         if not role:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -75,53 +84,189 @@ class RoleRepository(BaseSQLRepository[Role]):
             )
         return role
 
-    def delete_role(self, payload: RoleDeleteModel, deleted_by: UserReadModel) -> dict:
+    def create_role(
+        self, payload: RoleCreateModel, created_by: UserReadModel
+    ) -> RoleReadModel:
         try:
-            if payload.role_name_to_delete == payload.replacement_role_name:
-                raise ValueError("Cannot replace a role with itself.")
-
-            role_to_delete = self.get_role_record(payload.role_name_to_delete)
-            if not role_to_delete:
-                raise ValueError(f"Role '{payload.role_name_to_delete}' not found.")
-
-            replacement_role = self.get_role_record(payload.replacement_role_name)
-            if not replacement_role:
-                raise ValueError(
-                    f"Replacement role '{payload.replacement_role_name}' not found."
-                )
-
-            reassigned_count = 0
-            for user_link in role_to_delete.users:
-                user_link.role = replacement_role
-                reassigned_count += 1
-
-            role_to_delete._closed_at = self._now_sql()
-            self.db_session.add(role_to_delete)
-            self.db_session.commit()
-            self.update_json_field(
-                role_to_delete,
-                column_name="primary_meta_data",
-                key="deleted_by",
-                value=deleted_by.model_dump(mode="json"),
+            role = self.create(
+                name=payload.name,
+                description=payload.description,
             )
-
-            return {
-                "message": (
-                    f"Role '{payload.role_name_to_delete}' soft deleted and users reassigned "
-                    f"to '{payload.replacement_role_name}'."
-                ),
-                "users_reassigned": reassigned_count,
-            }
+            role = self.update_json_field(
+                role,
+                column_name="primary_meta_data",
+                key="created_by",
+                value=created_by.model_dump(mode="json"),
+            )
+            return self._to_read_model(role)
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=CompanyRoleResponseMessages.ROLE_ALREADY_EXISTS.value,
+                error=str(exc),
+            ) from exc
         except Exception as exc:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_CREATION_FAILED.value,
+                error=str(exc),
+            ) from exc
+
+    def update_role(self, role_id: UUID, payload: RoleUpdateModel) -> RoleReadModel:
+        try:
+            role = self.get_role_record(role_id)
+            if not role:
+                raise ValueError(f"Role with id='{role_id}' not found.")
+            if payload.name:
+                role.name = payload.name
+            if payload.description is not None:
+                role.description = payload.description
+            self.db_session.commit()
+            self.db_session.refresh(role)
+            return self._to_read_model(role)
+        except Exception as exc:
+            self.db_session.rollback()
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
                 error=str(exc),
             ) from exc
 
-    def update_role(self, name: str, payload: RoleUpdateModel) -> RoleReadModel:
+    def delete_role(self, role_id: UUID, deleted_by: UserReadModel) -> dict:
         try:
-            role = self.get_role_record(name)
+            role = self.get_role_record(role_id)
+            if not role:
+                raise ValueError(f"Role with id='{role_id}' not found.")
+            if (
+                self.db_session.query(AssociationUserCompany)
+                .filter(
+                    AssociationUserCompany.role_id == role_id,
+                    AssociationUserCompany._closed_at.is_(None),
+                )
+                .count()
+            ):
+                raise ValueError(
+                    "Cannot delete a role that is still assigned to active company users."
+                )
+
+            role._closed_at = self._now_sql()
+            self.db_session.add(role)
+            self.db_session.commit()
+            self.update_json_field(
+                role,
+                column_name="primary_meta_data",
+                key="deleted_by",
+                value=deleted_by.model_dump(mode="json"),
+            )
+            return {"message": f"Role '{role.name}' deleted successfully."}
+        except Exception as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value,
+                error=str(exc),
+            ) from exc
+
+
+class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
+    model = CompanyRole
+
+    def __init__(self, company_id: UUID, session: Session):
+        super().__init__(session)
+        self.company_id = company_id
+
+    def get_company_roles(self, payload: RoleQueryParamsModel) -> dict:
+        try:
+            query = (
+                self.db_session.query(Role)
+                .join(CompanyRole, CompanyRole.role_id == Role.id)
+                .filter(
+                    CompanyRole.company_id == self.company_id,
+                    CompanyRole._closed_at.is_(None),
+                    Role._closed_at.is_(None),
+                )
+            )
+            if payload.name:
+                query = query.filter(Role.name.ilike(f"%{payload.name}%"))
+            if payload.description:
+                query = query.filter(Role.description.ilike(f"%{payload.description}%"))
+            return self.paginate(
+                query,
+                page=payload.page,
+                limit=payload.limit,
+                order_by=[Role.name.asc()],
+            )
+            records = []
+            for role in result["records"]:
+                role["id"] = str(role["id"])
+                records.append(role)
+            result["records"] = records
+            return result
+        except Exception as exc:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_NOT_FOUND.value,
+                error=str(exc),
+            ) from exc
+
+    def get_assignment(self, role_id: UUID) -> CompanyRole | None:
+        return (
+            self._base_query()
+            .filter(
+                CompanyRole.company_id == self.company_id,
+                CompanyRole.role_id == role_id,
+                CompanyRole._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+
+    def ensure_role_assigned(self, role_id: UUID) -> CompanyRole:
+        assignment = self.get_assignment(role_id)
+        if not assignment:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyUserResponseMessages.ADD_USER_FAILED.value,
+                error="Role is not linked to the company",
+            )
+        return assignment
+
+    def ensure_role_name_assigned(self, role_name: str) -> Role:
+        role = (
+            self.db_session.query(Role)
+            .join(CompanyRole, CompanyRole.role_id == Role.id)
+            .filter(
+                CompanyRole.company_id == self.company_id,
+                CompanyRole._closed_at.is_(None),
+                Role.name == role_name,
+                Role._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+        if not role:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyUserResponseMessages.ADD_USER_FAILED.value,
+                error=f"Role: {role_name} is not linked to the company",
+            )
+        return role
+
+    def get_role_name_assigned(self, role_name: str) -> Role | None:
+        return (
+            self.db_session.query(Role)
+            .join(CompanyRole, CompanyRole.role_id == Role.id)
+            .filter(
+                CompanyRole.company_id == self.company_id,
+                CompanyRole._closed_at.is_(None),
+                Role.name == role_name,
+                Role._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+
+    def update_company_role(self, name: str, payload: RoleUpdateModel) -> RoleReadModel:
+        try:
+            role = self.get_role_name_assigned(name)
             if not role:
                 raise ValueError(
                     f"Role with company_id={self.company_id} and name='{name}' not found."
@@ -132,33 +277,142 @@ class RoleRepository(BaseSQLRepository[Role]):
                 role.description = payload.description
             self.db_session.commit()
             self.db_session.refresh(role)
-            return self._to_read_model(role)
+            return RoleRepository._to_read_model(role)
         except Exception as exc:
+            self.db_session.rollback()
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
                 error=str(exc),
             ) from exc
 
-    def create_role(
-        self, payload: RoleCreateModel, created_by: UserReadModel
-    ) -> RoleReadModel:
-        try:
-            role = self.create(
-                name=payload.name,
-                description=payload.description,
-                company_id=self.company_id,
-            )
-            role = self.update_json_field(
-                role,
-                column_name="primary_meta_data",
-                key="created_by",
-                value=created_by.model_dump(mode="json"),
-            )
-            return self._to_read_model(role)
-        except Exception as exc:
+    def assign_role(self, role: Role, assigned_by: UserReadModel) -> RoleReadModel:
+        existing = self.get_assignment(role.id)
+        if existing:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 message=CompanyRoleResponseMessages.ROLE_CREATION_FAILED.value,
-                error=str(exc),
-            ) from exc
+                error="Role is already assigned to the company",
+            )
+
+        assignment = self.create(company_id=self.company_id, role_id=role.id)
+        self.update_json_field(
+            assignment,
+            column_name="primary_meta_data",
+            key="assigned_by",
+            value=assigned_by.model_dump(mode="json"),
+        )
+        return RoleRepository._to_read_model(role)
+
+    def assign_role_to_companies(
+        self,
+        role: Role,
+        payload: RoleAssignCompaniesModel,
+        assigned_by: UserReadModel,
+    ) -> dict:
+        assigned_companies: list[str] = []
+        for company_id in payload.company_ids:
+            company_uuid = UUID(company_id)
+            repository = CompanyRoleAssignmentRepository(company_uuid, self.db_session)
+            if repository.get_assignment(role.id):
+                continue
+            assignment = repository.create(company_id=company_uuid, role_id=role.id)
+            repository.update_json_field(
+                assignment,
+                column_name="primary_meta_data",
+                key="assigned_by",
+                value=assigned_by.model_dump(mode="json"),
+            )
+            assigned_companies.append(company_id)
+        return {"role_id": str(role.id), "company_ids": assigned_companies}
+
+    def unassign_role(self, role_id: UUID) -> dict:
+        assignment = self.get_assignment(role_id)
+        if not assignment:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=CompanyRoleResponseMessages.ROLE_NOT_FOUND.value,
+                error="Role assignment not found.",
+            )
+        if (
+            self.db_session.query(AssociationUserCompany)
+            .filter(
+                AssociationUserCompany.company_id == self.company_id,
+                AssociationUserCompany.role_id == role_id,
+                AssociationUserCompany._closed_at.is_(None),
+            )
+            .count()
+        ):
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value,
+                error="Cannot unassign a role that is still assigned to active company users.",
+            )
+        assignment._closed_at = self._now_sql()
+        self.db_session.add(assignment)
+        self.db_session.commit()
+        return {"message": "Role unassigned successfully."}
+
+    def reassign_and_delete_role(
+        self, payload: RoleDeleteModel, deleted_by: UserReadModel
+    ) -> dict:
+        if payload.role_name_to_delete == payload.replacement_role_name:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                error="Cannot replace a role with itself.",
+            )
+
+        role_to_delete = self.get_role_name_assigned(payload.role_name_to_delete)
+        if not role_to_delete:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                error=f"Role '{payload.role_name_to_delete}' not found.",
+            )
+        replacement_role = self.get_role_name_assigned(payload.replacement_role_name)
+        if not replacement_role:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                error=f"Replacement role '{payload.replacement_role_name}' not found.",
+            )
+
+        reassigned_count = 0
+        active_links = (
+            self.db_session.query(AssociationUserCompany)
+            .filter(
+                AssociationUserCompany.company_id == self.company_id,
+                AssociationUserCompany.role_id == role_to_delete.id,
+                AssociationUserCompany._closed_at.is_(None),
+            )
+            .all()
+        )
+        for user_link in active_links:
+            user_link.role_id = replacement_role.id
+            reassigned_count += 1
+
+        assignment = self.get_assignment(role_to_delete.id)
+        if not assignment:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+                error=f"Role '{payload.role_name_to_delete}' not found.",
+            )
+        assignment._closed_at = self._now_sql()
+        self.db_session.add(assignment)
+        self.db_session.commit()
+        self.update_json_field(
+            assignment,
+            column_name="primary_meta_data",
+            key="deleted_by",
+            value=deleted_by.model_dump(mode="json"),
+        )
+
+        return {
+            "message": (
+                f"Role '{payload.role_name_to_delete}' unassigned and users reassigned "
+                f"to '{payload.replacement_role_name}'."
+            ),
+            "users_reassigned": reassigned_count,
+        }

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -17,6 +17,7 @@ from app.models.generic_pagination import (
 )
 from app.models.user.user import UserQueryParams
 from app.repository.base import BaseSQLRepository
+from app.repository.company_role import CompanyRoleAssignmentRepository
 from app.repository.database.tables import AssociationUserCompany, Role, User
 from app.utils.app_error import AppError
 
@@ -28,7 +29,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         super().__init__(session)
 
     @staticmethod
-    def _to_company_user(user: User, role_name: str) -> CompanyUserReadModel:
+    def _to_company_user(user: User, role: Role) -> CompanyUserReadModel:
         metadata = user.primary_meta_data or {}
         return CompanyUserReadModel(
             id=user.id,
@@ -38,7 +39,8 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             phone_number=user.phone_number,
             status=metadata.get("status"),
             is_superuser=user.is_superuser,
-            role_name=role_name,
+            role_id=str(role.id),
+            role_name=role.name,
         )
 
     def is_user_linked_to_company(
@@ -55,7 +57,9 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             _closed_at=None,
         )
         if resolved_role_name:
-            query = query.filter_by(role_name=resolved_role_name)
+            query = query.join(AssociationUserCompany.role).filter(
+                Role.name == resolved_role_name
+            )
         return self.db_session.query(query.exists()).scalar()
 
     def ensure_user_linked_to_company(
@@ -80,21 +84,9 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
                 error=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
             )
 
-        role = (
-            self.db_session.query(Role)
-            .filter(
-                Role.company_id == company_id,
-                Role.name == payload.role,
-                Role._closed_at.is_(None),
-            )
-            .one_or_none()
-        )
-        if not role:
-            raise AppError(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                message=CompanyUserResponseMessages.ADD_USER_FAILED.value,
-                error=f"Role: {payload.role} is not linked to the company",
-            )
+        role = CompanyRoleAssignmentRepository(
+            company_id=company_id, session=self.db_session
+        ).ensure_role_name_assigned(payload.role)
 
         existing = (
             self._base_query()
@@ -110,10 +102,11 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         assoc = self.create(
             user_id=user.id,
             company_id=company_id,
-            role_name=role.name,
+            role_id=role.id,
             primary_meta_data={"added_by": added_by.model_dump(mode="json")},
+            secondary_meta_data={"_legacy_role_name": role.name},
         )
-        return self._to_company_user(user, assoc.role_name)
+        return self._to_company_user(user, role)
 
     def remove_user_from_company(
         self, company_id: UUID, user_id: UUID, removed_by
@@ -131,7 +124,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
 
         if (
             assoc.user_id == removed_by.id
-            and assoc.role_name == CompanyDefaultRoles.ADMINISTRATOR.name_value
+            and assoc.role.name == CompanyDefaultRoles.ADMINISTRATOR.name_value
         ):
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -146,26 +139,14 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         self.db_session.refresh(assoc)
 
         user = self.db_session.query(User).filter(User.id == user_id).one()
-        return self._to_company_user(user, assoc.role_name)
+        return self._to_company_user(user, assoc.role)
 
     def update_user_role(
         self, company_id: UUID, user_id: UUID, role_name: str, updated_by
     ) -> CompanyUserReadModel:
-        role = (
-            self.db_session.query(Role)
-            .filter(
-                Role.company_id == company_id,
-                Role.name == role_name,
-                Role._closed_at.is_(None),
-            )
-            .one_or_none()
-        )
-        if not role:
-            raise AppError(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                message=CompanyUserResponseMessages.UPDATE_USER_ROLE_FAILED.value,
-                error=f"Role: {role_name} is not linked to the company",
-            )
+        role = CompanyRoleAssignmentRepository(
+            company_id=company_id, session=self.db_session
+        ).ensure_role_name_assigned(role_name)
 
         assoc = (
             self._base_query()
@@ -179,15 +160,17 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
                 error=CompanyResponseMessages.COMPANY_NOT_FOUND.value,
             )
 
-        assoc.role_name = role.name
+        assoc.role_id = role.id
         assoc.primary_meta_data["updated_by"] = updated_by.model_dump(mode="json")
+        assoc.secondary_meta_data["_legacy_role_name"] = role.name
         flag_modified(assoc, "primary_meta_data")
+        flag_modified(assoc, "secondary_meta_data")
         self.db_session.add(assoc)
         self.db_session.commit()
         self.db_session.refresh(assoc)
 
         user = self.db_session.query(User).filter(User.id == user_id).one()
-        return self._to_company_user(user, assoc.role_name)
+        return self._to_company_user(user, role)
 
     def get_company_users(
         self, company_id: UUID, params: UserQueryParams
@@ -195,6 +178,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         query = (
             self.db_session.query(AssociationUserCompany)
             .join(AssociationUserCompany.user)
+            .join(AssociationUserCompany.role)
             .filter(
                 AssociationUserCompany.company_id == company_id,
                 AssociationUserCompany._closed_at.is_(None),
@@ -203,9 +187,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         )
 
         if params.role_name:
-            query = query.filter(
-                AssociationUserCompany.role_name.ilike(f"%{params.role_name}%")
-            )
+            query = query.filter(Role.name.ilike(f"%{params.role_name}%"))
         if params.first_name:
             query = query.filter(User.first_name.ilike(f"%{params.first_name}%"))
         if params.last_name:
@@ -215,7 +197,10 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
 
         total = query.count()
         results = apply_pagination(
-            query.options(joinedload(AssociationUserCompany.user)),
+            query.options(
+                joinedload(AssociationUserCompany.user),
+                joinedload(AssociationUserCompany.role),
+            ),
             page=params.page,
             limit=params.limit,
             order_by=[
@@ -225,7 +210,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         ).all()
 
         users = [
-            self._to_company_user(assoc.user, assoc.role_name) for assoc in results
+            self._to_company_user(assoc.user, assoc.role) for assoc in results
         ]
         return PaginatedResponse[CompanyUserReadModel](
             records=users,

--- a/app/repository/database/session_manager.py
+++ b/app/repository/database/session_manager.py
@@ -16,6 +16,7 @@ class DatabaseSessionManager:
     expected_tables = (
         "association_user_company",
         "company",
+        "company_role",
         "role",
         "user",
     )
@@ -74,6 +75,7 @@ class DatabaseSessionManager:
         from app.repository.database.tables import (  # noqa: F401
             AssociationUserCompany,
             Company,
+            CompanyRole,
             Role,
             User,
         )

--- a/app/repository/database/session_manager.py
+++ b/app/repository/database/session_manager.py
@@ -20,6 +20,17 @@ class DatabaseSessionManager:
         "role",
         "user",
     )
+    expected_columns = {
+        "association_user_company": {"user_id", "company_id", "role_id"},
+        "company": {"id", "email"},
+        "company_role": {"company_id", "role_id"},
+        "role": {"id", "name", "description"},
+        "user": {"id", "email", "password"},
+    }
+    forbidden_columns = {
+        "association_user_company": {"role_name", "user_level"},
+        "role": {"company_id"},
+    }
 
     def __init__(self) -> None:
         self._base = Base
@@ -28,10 +39,15 @@ class DatabaseSessionManager:
 
         self.engine = self._configure_engine()
 
-        tables_exist = self._tables_exist()
-        if settings.DB_AUTO_CREATE and not tables_exist:
+        table_state = self._table_state()
+        if settings.DB_AUTO_CREATE and table_state == "missing":
             self._base.metadata.create_all(bind=self.engine)
-        elif not tables_exist and not settings.TESTING:
+        elif table_state in {"partial", "incompatible"}:
+            raise RuntimeError(
+                "Database schema is incompatible with current models; run Alembic "
+                "migrations or recreate the database."
+            )
+        elif table_state == "missing" and not settings.TESTING:
             raise RuntimeError(
                 "Database schema is not initialized; run Alembic migrations before startup"
             )
@@ -80,11 +96,35 @@ class DatabaseSessionManager:
             User,
         )
 
-    def _tables_exist(self) -> bool:
+    def _table_state(self) -> str:
         inspector = inspect(self.engine)
-        return all(
-            inspector.has_table(table_name) for table_name in self.expected_tables
-        )
+        existing_tables = {
+            table_name
+            for table_name in self.expected_tables
+            if inspector.has_table(table_name)
+        }
+        if not existing_tables:
+            return "missing"
+        if existing_tables != set(self.expected_tables):
+            return "partial"
+        if not self._schema_matches_models(inspector):
+            return "incompatible"
+        return "ok"
+
+    def _tables_exist(self) -> bool:
+        return self._table_state() == "ok"
+
+    def _schema_matches_models(self, inspector) -> bool:
+        for table_name, required_columns in self.expected_columns.items():
+            actual_columns = {
+                column["name"] for column in inspector.get_columns(table_name)
+            }
+            if not required_columns.issubset(actual_columns):
+                return False
+            forbidden = self.forbidden_columns.get(table_name, set())
+            if actual_columns.intersection(forbidden):
+                return False
+        return True
 
     def get_session(self) -> Generator[Session, None, None]:
         db = self.SessionLocal()

--- a/app/repository/database/tables/__init__.py
+++ b/app/repository/database/tables/__init__.py
@@ -2,7 +2,8 @@ from app.repository.database.tables.association_user_company import (
     AssociationUserCompany,
 )
 from app.repository.database.tables.company import Company
+from app.repository.database.tables.company_role import CompanyRole
 from app.repository.database.tables.role import Role
 from app.repository.database.tables.user import User
 
-__all__ = ["AssociationUserCompany", "Company", "Role", "User"]
+__all__ = ["AssociationUserCompany", "Company", "CompanyRole", "Role", "User"]

--- a/app/repository/database/tables/association_user_company.py
+++ b/app/repository/database/tables/association_user_company.py
@@ -1,6 +1,6 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from sqlalchemy import ForeignKey, ForeignKeyConstraint, String, Uuid
+from sqlalchemy import ForeignKey, Uuid
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -27,19 +27,58 @@ class AssociationUserCompany(BaseModel):
         ForeignKey("company.id"),
         primary_key=True,
     )
-    role_name: Mapped[str] = mapped_column(String(256), nullable=False)
-
-    __table_args__ = (
-        ForeignKeyConstraint(
-            ["company_id", "role_name"],
-            ["role.company_id", "role.name"],
-            ondelete="CASCADE",
-        ),
+    role_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("role.id", ondelete="CASCADE"),
+        nullable=False,
     )
 
     role = relationship("Role", back_populates="users", overlaps="company,users")
     company = relationship("Company", back_populates="users", overlaps="role")
     user = relationship("User", back_populates="companies", overlaps="company,role")
+
+    @property
+    def role_name(self) -> str | None:
+        if "role" in self.__dict__ and self.__dict__["role"] is not None:
+            return self.__dict__["role"].name
+        return (self.secondary_meta_data or {}).get("_legacy_role_name")
+
+    @role_name.setter
+    def role_name(self, value: str) -> None:
+        self.secondary_meta_data = self.secondary_meta_data or {}
+        self.secondary_meta_data["_legacy_role_name"] = value
+        if getattr(self, "role_id", None) is None:
+            self.role_id = uuid4()
+
+    @staticmethod
+    def to_dict(obj):
+        data = BaseModel.to_dict(obj)
+        data["role_name"] = obj.role_name
+        return data
+
+    @classmethod
+    def create(cls, session: Session, **kwargs) -> dict:
+        role_name = kwargs.pop("role_name", None)
+        if role_name is not None and "role_id" not in kwargs:
+            role = Role.role_belongs_to_company(
+                session, kwargs["company_id"], role_name
+            )
+            kwargs["role_id"] = role["id"]
+        if role_name is not None:
+            secondary_meta_data = kwargs.get("secondary_meta_data") or {}
+            secondary_meta_data["_legacy_role_name"] = role_name
+            kwargs["secondary_meta_data"] = secondary_meta_data
+        return super().create(session, **kwargs)
+
+    @classmethod
+    def delete_by_filters(cls, session: Session, filters: dict) -> dict[str, str]:
+        role_name = filters.pop("role_name", None)
+        if role_name is not None:
+            role = Role.role_belongs_to_company(
+                session, filters["company_id"], role_name
+            )
+            filters["role_id"] = role["id"]
+        return super().delete_by_filters(session, filters)
 
     @classmethod
     def is_user_linked_to_company(
@@ -51,7 +90,7 @@ class AssociationUserCompany(BaseModel):
     ) -> bool:
         query = session.query(cls).filter_by(user_id=user_id, company_id=company_id)
         if role_name:
-            query = query.filter_by(role_name=role_name)
+            query = query.join(cls.role).filter(Role.name == role_name)
         return session.query(query.exists()).scalar()
 
     @classmethod
@@ -60,9 +99,12 @@ class AssociationUserCompany(BaseModel):
         session: Session,
         company_id: UUID,
         user_id: UUID,
-        role_name: str,
+        role_id: UUID | str,
         added_by: UserReadModel,
     ) -> "AssociationUserCompany":
+        if isinstance(role_id, str):
+            role = Role.role_belongs_to_company(session, company_id, role_id)
+            role_id = role["id"]
         existing = (
             session.query(cls)
             .filter_by(user_id=user_id, company_id=company_id, _closed_at=None)
@@ -74,7 +116,7 @@ class AssociationUserCompany(BaseModel):
         assoc = cls(
             user_id=user_id,
             company_id=company_id,
-            role_name=role_name,
+            role_id=role_id,
             primary_meta_data={"added_by": added_by.model_dump(mode="json")},
         )
         session.add(assoc)
@@ -102,7 +144,7 @@ class AssociationUserCompany(BaseModel):
             )
         if (
             assoc.user_id == removed_by.id
-            and assoc.role_name == CompanyDefaultRoles.ADMINISTRATOR.name_value
+            and assoc.role.name == CompanyDefaultRoles.ADMINISTRATOR.name_value
         ):
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -114,3 +156,6 @@ class AssociationUserCompany(BaseModel):
         session.commit()
         session.refresh(assoc)
         return assoc
+
+
+from app.repository.database.tables.role import Role

--- a/app/repository/database/tables/company.py
+++ b/app/repository/database/tables/company.py
@@ -26,9 +26,10 @@ class Company(BaseModel):
         overlaps="role,user",
     )
     roles = relationship(
-        "Role",
+        "CompanyRole",
         back_populates="company",
         cascade="all, delete-orphan",
+        overlaps="role",
     )
 
     @classmethod

--- a/app/repository/database/tables/company_role.py
+++ b/app/repository/database/tables/company_role.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.repository.database.base_model import BaseModel
+
+
+class CompanyRole(BaseModel):
+    __tablename__ = "company_role"
+
+    company_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("company.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("role.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    __table_args__ = (UniqueConstraint("company_id", "role_id", name="uq_company_role"),)
+
+    company = relationship("Company", back_populates="roles", overlaps="role")
+    role = relationship("Role", back_populates="companies", overlaps="company")

--- a/app/repository/database/tables/role.py
+++ b/app/repository/database/tables/role.py
@@ -1,13 +1,12 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from sqlalchemy import ForeignKey, String, Uuid
+from sqlalchemy import String, Uuid
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
-from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.company.response_messages import CompanyUserResponseMessages
-from app.models.user.user import UserReadModel
 from app.repository.database.base_model import BaseModel
 from app.utils.app_error import AppError
 from fastapi import status
@@ -16,20 +15,69 @@ from fastapi import status
 class Role(BaseModel):
     __tablename__ = "role"
 
-    company_id: Mapped[UUID] = mapped_column(
-        Uuid,
-        ForeignKey("company.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    name: Mapped[str] = mapped_column(String(256), primary_key=True)
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(String(256), nullable=True)
 
-    company = relationship("Company", back_populates="roles", overlaps="users")
+    companies = relationship(
+        "CompanyRole",
+        back_populates="role",
+        cascade="all, delete-orphan",
+        overlaps="company",
+    )
     users = relationship(
         "AssociationUserCompany",
         back_populates="role",
-        overlaps="company,users",
+        overlaps="company,companies",
     )
+
+    @staticmethod
+    def to_dict(obj):
+        data = BaseModel.to_dict(obj)
+        company_links = getattr(obj, "companies", None)
+        if company_links:
+            active_link = next(
+                (link for link in company_links if getattr(link, "_closed_at", None) is None),
+                None,
+            )
+            if active_link is not None:
+                data["company_id"] = active_link.company_id
+        return data
+
+    @classmethod
+    def create(cls, session: Session, **kwargs) -> dict:
+        company_id = kwargs.pop("company_id", None)
+        if company_id is not None:
+            existing_role = (
+                session.query(cls)
+                .filter(cls.name == kwargs["name"], cls._closed_at.is_(None))
+                .one_or_none()
+            )
+            if existing_role is not None:
+                existing_assignment = (
+                    session.query(CompanyRole)
+                    .filter_by(
+                        company_id=company_id,
+                        role_id=existing_role.id,
+                        _closed_at=None,
+                    )
+                    .one_or_none()
+                )
+                if existing_assignment is not None:
+                    raise ValueError("Integrity error: role already assigned to company")
+                session.add(CompanyRole(company_id=company_id, role_id=existing_role.id))
+                session.commit()
+                role_dict = cls.to_dict(existing_role)
+                role_dict["company_id"] = company_id
+                return role_dict
+        role_dict = super().create(session, **kwargs)
+        if company_id is not None:
+            role = session.query(cls).filter_by(id=role_dict["id"]).one()
+            assignment = CompanyRole(company_id=company_id, role_id=role.id)
+            session.add(assignment)
+            session.commit()
+            role_dict["company_id"] = company_id
+        return role_dict
 
     @classmethod
     def role_belongs_to_company(
@@ -37,7 +85,13 @@ class Role(BaseModel):
     ) -> dict:
         role = (
             session.query(cls)
-            .filter_by(company_id=company_id, name=role_name, _closed_at=None)
+            .join(cls.companies)
+            .filter(
+                cls.name == role_name,
+                cls._closed_at.is_(None),
+                CompanyRole.company_id == company_id,
+                CompanyRole._closed_at.is_(None),
+            )
             .one_or_none()
         )
         if role:
@@ -49,6 +103,50 @@ class Role(BaseModel):
         )
 
     @classmethod
+    def update_by_filters(cls, session: Session, filters: dict, **kwargs) -> dict:
+        company_id = filters.pop("company_id", None)
+        if company_id is not None:
+            role = (
+                session.query(cls)
+                .join(cls.companies)
+                .filter(
+                    CompanyRole.company_id == company_id,
+                    cls.name == filters["name"],
+                    cls._closed_at.is_(None),
+                    CompanyRole._closed_at.is_(None),
+                )
+                .one()
+            )
+            for field, value in kwargs.items():
+                setattr(role, field, value)
+            session.commit()
+            session.refresh(role)
+            data = cls.to_dict(role)
+            data["company_id"] = company_id
+            return data
+        return super().update_by_filters(session, filters, **kwargs)
+
+    @classmethod
+    def delete_by_filters(cls, session: Session, filters: dict) -> dict[str, str]:
+        company_id = filters.pop("company_id", None)
+        if company_id is not None:
+            assignment = (
+                session.query(CompanyRole)
+                .join(CompanyRole.role)
+                .filter(
+                    CompanyRole.company_id == company_id,
+                    Role.name == filters["name"],
+                    CompanyRole._closed_at.is_(None),
+                )
+                .one()
+            )
+            assignment._closed_at = func.now()
+            session.add(assignment)
+            session.commit()
+            return {"message": f"{cls.__name__} with filters deleted"}
+        return super().delete_by_filters(session, filters)
+
+    @classmethod
     def update_role(
         cls,
         session: Session,
@@ -58,7 +156,17 @@ class Role(BaseModel):
         new_description: str | None = None,
     ) -> dict:
         try:
-            role = session.query(cls).filter_by(company_id=company_id, name=name).one()
+            role = (
+                session.query(cls)
+                .join(cls.companies)
+                .filter(
+                    CompanyRole.company_id == company_id,
+                    cls.name == name,
+                    cls._closed_at.is_(None),
+                    CompanyRole._closed_at.is_(None),
+                )
+                .one()
+            )
             if new_name:
                 role.name = new_name
             if new_description:
@@ -82,7 +190,15 @@ class Role(BaseModel):
         value,
     ):
         role = (
-            session.query(cls).filter_by(company_id=company_id, name=name).one_or_none()
+            session.query(cls)
+            .join(cls.companies)
+            .filter(
+                CompanyRole.company_id == company_id,
+                cls.name == name,
+                cls._closed_at.is_(None),
+                CompanyRole._closed_at.is_(None),
+            )
+            .one_or_none()
         )
         if not role:
             raise ValueError(
@@ -106,14 +222,20 @@ class Role(BaseModel):
         company_id: UUID,
         name_to_delete: str,
         replacement_name: str,
-        deleted_by: UserReadModel,
+        deleted_by,
     ):
         if name_to_delete == replacement_name:
             raise ValueError("Cannot replace a role with itself.")
 
         role_to_delete = (
             session.query(cls)
-            .filter_by(company_id=company_id, name=name_to_delete)
+            .join(cls.companies)
+            .filter(
+                CompanyRole.company_id == company_id,
+                cls.name == name_to_delete,
+                cls._closed_at.is_(None),
+                CompanyRole._closed_at.is_(None),
+            )
             .one_or_none()
         )
         if not role_to_delete:
@@ -121,19 +243,34 @@ class Role(BaseModel):
 
         replacement_role = (
             session.query(cls)
-            .filter_by(company_id=company_id, name=replacement_name)
+            .join(cls.companies)
+            .filter(
+                CompanyRole.company_id == company_id,
+                cls.name == replacement_name,
+                cls._closed_at.is_(None),
+                CompanyRole._closed_at.is_(None),
+            )
             .one_or_none()
         )
         if not replacement_role:
             raise ValueError(f"Replacement role '{replacement_name}' not found.")
 
         reassigned_count = 0
-        for user_link in role_to_delete.users:
-            user_link.role = replacement_role
+        for user_link in (
+            session.query(AssociationUserCompany)
+            .filter_by(company_id=company_id, role_id=role_to_delete.id, _closed_at=None)
+            .all()
+        ):
+            user_link.role_id = replacement_role.id
             reassigned_count += 1
 
-        role_to_delete._closed_at = func.now()
-        session.add(role_to_delete)
+        assignment = (
+            session.query(CompanyRole)
+            .filter_by(company_id=company_id, role_id=role_to_delete.id, _closed_at=None)
+            .one()
+        )
+        assignment._closed_at = func.now()
+        session.add(assignment)
         session.commit()
         cls.update_json_field(
             session=session,
@@ -151,3 +288,7 @@ class Role(BaseModel):
             ),
             "users_reassigned": reassigned_count,
         }
+
+
+from app.repository.database.tables.company_role import CompanyRole
+from app.repository.database.tables.association_user_company import AssociationUserCompany

--- a/app/repository/database/tables/role.py
+++ b/app/repository/database/tables/role.py
@@ -1,7 +1,8 @@
 from uuid import UUID, uuid4
 
-from sqlalchemy import String, Uuid
+from sqlalchemy import String, Uuid, select
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import column_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
@@ -262,6 +263,8 @@ class Role(BaseModel):
             .all()
         ):
             user_link.role_id = replacement_role.id
+            user_link.secondary_meta_data = user_link.secondary_meta_data or {}
+            user_link.secondary_meta_data["_legacy_role_name"] = replacement_role.name
             reassigned_count += 1
 
         assignment = (
@@ -269,17 +272,15 @@ class Role(BaseModel):
             .filter_by(company_id=company_id, role_id=role_to_delete.id, _closed_at=None)
             .one()
         )
+        role_to_delete.primary_meta_data = role_to_delete.primary_meta_data or {}
+        role_to_delete.primary_meta_data["deleted_by"] = deleted_by.model_dump(
+            mode="json"
+        )
+        role_to_delete._closed_at = func.now()
         assignment._closed_at = func.now()
+        session.add(role_to_delete)
         session.add(assignment)
         session.commit()
-        cls.update_json_field(
-            session=session,
-            company_id=company_id,
-            name=name_to_delete,
-            column_name="primary_meta_data",
-            key="deleted_by",
-            value=deleted_by.model_dump(mode="json"),
-        )
         session.refresh(role_to_delete)
         return {
             "message": (
@@ -292,3 +293,12 @@ class Role(BaseModel):
 
 from app.repository.database.tables.company_role import CompanyRole
 from app.repository.database.tables.association_user_company import AssociationUserCompany
+
+Role.company_id = column_property(
+    select(CompanyRole.company_id)
+    .where(CompanyRole.role_id == Role.id)
+    .correlate_except(CompanyRole)
+    .order_by(CompanyRole._created_at.desc())
+    .limit(1)
+    .scalar_subquery()
+)

--- a/app/services/company/role.py
+++ b/app/services/company/role.py
@@ -2,26 +2,23 @@ from uuid import UUID
 
 from fastapi import status
 
-# utils
-from app.services.company.user import CompanyUserService
-from app.models.generic_pagination import PaginatedResponse
-from app.utils.app_error import AppError
-
-# repository
-from app.repository.company_role import RoleRepository
-
-# models
+from app.models.company.response_messages import CompanyRoleResponseMessages
 from app.models.company.roles import (
     CompanyDefaultRoles,
+    RoleAssignCompaniesModel,
+    RoleCreateModel,
     RoleDeleteModel,
     RoleQueryParamsModel,
-    RoleCreateModel,
     RoleReadModel,
     RoleUpdateModel,
 )
-from app.models.company.response_messages import (
-    CompanyRoleResponseMessages,
+from app.models.generic_pagination import PaginatedResponse
+from app.repository.company_role import (
+    CompanyRoleAssignmentRepository,
+    RoleRepository,
 )
+from app.services.company.user import CompanyUserService
+from app.utils.app_error import AppError
 from app.utils.shared_context import SharedContext
 
 
@@ -48,36 +45,10 @@ class RoleService:
                 message="Access denied. You are not authorized to access this company.",
             )
 
-    def update_role(
-        self, company_id: UUID, name: str, payload: RoleUpdateModel
-    ) -> RoleReadModel:
-        """
-        Update the description or name of a role for a company.
-        """
-        self._ensure_company_manager(company_id)
-        role_repository = RoleRepository(
-            company_id=company_id, session=self.context.db_session
+    def create_role(self, payload: RoleCreateModel) -> RoleReadModel:
+        role = RoleRepository(self.context.db_session).create_role(
+            payload, self.context.user
         )
-        role = role_repository.update_role(
-            name=name,
-            payload=payload,
-        )
-        if not role:
-            raise AppError(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
-            )
-        return role
-
-    def create_role(self, payload: RoleCreateModel, company_id: UUID) -> RoleReadModel:
-        """
-        Create a new company role and store its creator in primary_meta_data.
-        """
-        self._ensure_company_manager(company_id)
-        role_repository = RoleRepository(
-            company_id=company_id, session=self.context.db_session
-        )
-        role = role_repository.create_role(payload, self.context.user)
         if not role:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -85,28 +56,113 @@ class RoleService:
             )
         return role
 
+    def get_roles(
+        self, payload: RoleQueryParamsModel
+    ) -> PaginatedResponse[RoleReadModel]:
+        result = RoleRepository(self.context.db_session).get_roles(payload=payload)
+        records = []
+        for role in result["records"]:
+            role["id"] = str(role["id"])
+            records.append(RoleReadModel(**role))
+        return PaginatedResponse[RoleReadModel](
+            records=records,
+            pagination=result["pagination"],
+        )
+
+    def update_role(self, role_id: UUID, payload: RoleUpdateModel) -> RoleReadModel:
+        role = RoleRepository(self.context.db_session).update_role(role_id, payload)
+        if not role:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+            )
+        return role
+
+    def update_company_role(
+        self, company_id: UUID, name: str, payload: RoleUpdateModel
+    ) -> RoleReadModel:
+        self._ensure_company_manager(company_id)
+        role = CompanyRoleAssignmentRepository(
+            company_id=company_id,
+            session=self.context.db_session,
+        ).update_company_role(name, payload)
+        if not role:
+            raise AppError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                message=CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value,
+            )
+        return role
+
+    def delete_global_role(self, role_id: UUID) -> dict:
+        return RoleRepository(self.context.db_session).delete_role(
+            role_id, self.context.user
+        )
+
+    def assign_role_to_company(self, company_id: UUID, role_id: UUID) -> RoleReadModel:
+        self._ensure_company_manager(company_id)
+        role = RoleRepository(self.context.db_session).ensure_role_exists(role_id)
+        return CompanyRoleAssignmentRepository(
+            company_id=company_id,
+            session=self.context.db_session,
+        ).assign_role(role, self.context.user)
+
+    def assign_role_to_companies(
+        self, role_id: UUID, payload: RoleAssignCompaniesModel
+    ) -> dict:
+        role = RoleRepository(self.context.db_session).ensure_role_exists(role_id)
+        for company_id in payload.company_ids:
+            self._ensure_company_manager(UUID(company_id))
+        if not payload.company_ids:
+            return {"role_id": str(role.id), "company_ids": []}
+        return CompanyRoleAssignmentRepository(
+            company_id=UUID(payload.company_ids[0]),
+            session=self.context.db_session,
+        ).assign_role_to_companies(role, payload, self.context.user)
+
+    def create_role_for_company(
+        self, payload: RoleCreateModel, company_id: UUID
+    ) -> RoleReadModel:
+        self._ensure_company_manager(company_id)
+        repository = RoleRepository(self.context.db_session)
+        existing_role = repository.get_role_by_name(payload.name)
+        if existing_role is not None:
+            role = RoleReadModel(
+                id=str(existing_role.id),
+                name=existing_role.name,
+                description=existing_role.description,
+            )
+        else:
+            role = self.create_role(payload)
+        self.assign_role_to_company(company_id, UUID(role.id))
+        return role
+
+    def unassign_role(self, company_id: UUID, role_id: UUID) -> dict:
+        self._ensure_company_manager(company_id)
+        return CompanyRoleAssignmentRepository(
+            company_id=company_id,
+            session=self.context.db_session,
+        ).unassign_role(role_id)
+
     def delete_role(self, payload: RoleDeleteModel, company_id: UUID) -> dict:
         self._ensure_company_manager(company_id)
-        role_repository = RoleRepository(
-            company_id=company_id, session=self.context.db_session
-        )
-        return role_repository.delete_role(
-            payload=payload, deleted_by=self.context.user
-        )
+        return CompanyRoleAssignmentRepository(
+            company_id=company_id,
+            session=self.context.db_session,
+        ).reassign_and_delete_role(payload, self.context.user)
 
     def get_company_roles(
         self, payload: RoleQueryParamsModel, company_id: UUID
     ) -> PaginatedResponse[RoleReadModel]:
-        """
-        Get company roles with pagination and optional filtering.
-        """
         self._ensure_company_manager(company_id)
-        role_repository = RoleRepository(
-            company_id=company_id, session=self.context.db_session
-        )
-        result = role_repository.get_roles(payload=payload)
-
+        result = CompanyRoleAssignmentRepository(
+            company_id=company_id,
+            session=self.context.db_session,
+        ).get_company_roles(payload=payload)
+        records = []
+        for role in result["records"]:
+            role["id"] = str(role["id"])
+            records.append(RoleReadModel(**role))
         return PaginatedResponse[RoleReadModel](
-            records=[RoleReadModel(**role) for role in result["records"]],
+            records=records,
             pagination=result["pagination"],
         )

--- a/app/services/company/role.py
+++ b/app/services/company/role.py
@@ -45,7 +45,11 @@ class RoleService:
                 message="Access denied. You are not authorized to access this company.",
             )
 
-    def create_role(self, payload: RoleCreateModel) -> RoleReadModel:
+    def create_role(
+        self, payload: RoleCreateModel, company_id: UUID | None = None
+    ) -> RoleReadModel:
+        if company_id is not None:
+            self._ensure_company_manager(company_id)
         role = RoleRepository(self.context.db_session).create_role(
             payload, self.context.user
         )
@@ -69,8 +73,18 @@ class RoleService:
             pagination=result["pagination"],
         )
 
-    def update_role(self, role_id: UUID, payload: RoleUpdateModel) -> RoleReadModel:
-        role = RoleRepository(self.context.db_session).update_role(role_id, payload)
+    def update_role(self, *args, **kwargs) -> RoleReadModel:
+        if len(args) == 3 and not kwargs:
+            company_id, name, payload = args
+            self._ensure_company_manager(company_id)
+            role = RoleRepository(
+                self.context.db_session,
+                company_id=company_id,
+            ).update_role(name, payload)
+        else:
+            role_id = kwargs.get("role_id", args[0] if args else None)
+            payload = kwargs.get("payload", args[1] if len(args) > 1 else None)
+            role = RoleRepository(self.context.db_session).update_role(role_id, payload)
         if not role:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,24 @@ REQUIRE_EMAIL_VERIFICATION=true
 
 For production databases, prefer Alembic migrations over automatic table creation. `DB_AUTO_CREATE` should generally be enabled only for local development or disposable test databases.
 
+`DB_AUTO_CREATE` only creates a completely missing schema. It does not repair old or partially migrated schemas. If the database contains an incompatible older layout, startup now fails fast and you must run:
+
+```bash
+uv run alembic upgrade head
+```
+
+This matters in particular for older local SQLite databases created before roles were normalized into a shared global `role` catalog plus `company_role` links.
+
+### Shared role catalog
+
+Roles are shared by name across companies. The current model is:
+
+- `role`: global role records such as `Owner`, `Administrator`, and `Viewer`
+- `company_role`: which companies currently use each role
+- `association_user_company.role_id`: the role assigned to a specific user inside a company
+
+If you are upgrading an older database where roles were stored per company, apply Alembic migrations before using the app or env-backed HTTP test mode.
+
 ## JWT Settings
 
 ```bash
@@ -233,6 +251,8 @@ Apply migrations:
 ```bash
 uv run alembic upgrade head
 ```
+
+The current branch includes a role-catalog normalization migration for older databases. Apply migrations before reusing an existing `development.db` or any long-lived local SQLite file.
 
 Create a migration:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,12 @@ Table models live in `app/repository/database/tables`. Session management lives 
 
 HTTP integration tests are under `tests/api/http`, not `tests/http`.
 
+They use an isolated temporary SQLite database by default. To run them against a specific env file and database, pass `--http-env-file`:
+
+```bash
+uv run pytest tests/api/http --http-env-file .env
+```
+
 ## How do I run the same command CI runs?
 
 Use:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,4 +39,4 @@ When `TESTING=true` or `ENVIRONMENT=testing`, SMTP delivery is skipped so tests 
 
 ## How is coverage configured?
 
-Coverage is configured in `pyproject.toml` under `[tool.coverage.*]`. CI enforces `95%` coverage and writes XML output to `coverage_reports/coverage.xml`.
+Coverage is configured in `pyproject.toml` under `[tool.coverage.*]`. CI enforces `96%` coverage and writes XML output to `coverage_reports/coverage.xml`.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -51,10 +51,10 @@ That script currently:
 uv run pytest -v --cov=app \
   --cov-report=term-missing \
   --cov-report=xml:coverage_reports/coverage.xml \
-  --cov-fail-under=95
+  --cov-fail-under=96
 ```
 
-Coverage must stay at or above `95%` or the job fails.
+Coverage must stay at or above `96%` or the job fails.
 
 ### Formatting behavior
 
@@ -247,4 +247,3 @@ Given the current implementation, the safest contributor workflow is:
 2. Run `./scripts/run_http_tests.sh` locally before opening a PR.
 3. Use `[minor]` or `[major]` in the commit message only when a real semantic version change is intended.
 4. Treat every push to `main` as release-producing automation.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,6 @@ These docs describe the current Userverse backend layout, configuration model, t
 Start with:
 
 - [Configuration](configuration.md) for runtime environment variables and database setup.
-- [Testing](testing.md) for pytest and coverage commands.
+- [Testing](testing.md) for pytest, coverage commands, and env-backed HTTP test runs.
 - [GitHub Workflows](github-workflows.md) for CI, release automation, and workflow improvement notes.
 - [FAQ](faq.md) for common local development issues.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,7 +22,7 @@ It then runs:
 pytest -v --cov=app \
   --cov-report=term-missing \
   --cov-report=xml:coverage_reports/coverage.xml \
-  --cov-fail-under=95
+  --cov-fail-under=96
 ```
 
 For local development, prefer focused runs:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,6 +30,7 @@ For local development, prefer focused runs:
 ```bash
 uv run pytest tests/api/http/a_user
 uv run pytest tests/api/http/b_company
+uv run pytest tests/api/http --http-env-file .env
 uv run pytest tests/api/security
 uv run pytest tests/database
 uv run pytest tests/utils
@@ -41,7 +42,33 @@ If `uv` cannot write to its default cache in a sandboxed environment, use:
 uv run --no-cache pytest tests/utils
 ```
 
-The HTTP suite uses a test SQLite database and patches email dispatch so tests do not perform network SMTP calls.
+By default, the HTTP suite uses a temporary SQLite database and patches email dispatch so tests do not perform network SMTP calls.
+
+If you need to seed or validate a non-temporary environment, pass `--http-env-file`:
+
+```bash
+uv run pytest tests/api/http/c_company_roles -q --http-env-file .env
+uv run pytest tests/api/http -q --http-env-file /path/to/.env
+```
+
+The env-backed mode loads variables from the specified dotenv file and uses its `DATABASE_URL` instead of the isolated test database. This is intended for explicit local seeding or environment verification, not default development or CI runs.
+
+The env file should define at least:
+
+```bash
+DATABASE_URL=sqlite:///./development.db
+```
+
+If omitted, the HTTP test harness falls back to:
+
+- `ENV=testing`
+- `ENVIRONMENT=testing`
+- `TESTING=true`
+- `DB_AUTO_CREATE=true`
+- `FRONTEND_URL=https://frontend.example.com/reset-password`
+- `JWT_SECRET=testing-secret-key-with-at-least-32-bytes`
+
+Use `--http-env-file` carefully: the HTTP fixtures can create, update, and reseed records in the target database.
 
 If you want to exercise the non-verification flow locally, run tests or manual API checks with:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 96
 show_missing = true
 
 

--- a/scripts/run_http_tests.sh
+++ b/scripts/run_http_tests.sh
@@ -27,7 +27,7 @@ echo "Generating Coverage Report Summary:"
 uv run pytest -v --cov=app \
     --cov-report=term-missing \
     --cov-report=xml:"$COVERAGE_DIR/coverage.xml" \
-    --cov-fail-under=95
+    --cov-fail-under=96
 
 
 echo "========================================="

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ The `scripts/run_http_tests.sh` script sets these values and runs pytest with co
 ./scripts/run_http_tests.sh
 ```
 
-Coverage output is written to `coverage_reports/coverage.xml`, and CI enforces a `95%` coverage threshold.
+Coverage output is written to `coverage_reports/coverage.xml`, and CI enforces a `96%` coverage threshold.
 
 ## Directory Structure
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,7 @@ API HTTP tests:
 
 ```bash
 uv run pytest tests/api/http
+uv run pytest tests/api/http --http-env-file .env
 ```
 
 User API tests:
@@ -89,7 +90,9 @@ uv run pytest tests/utils
 
 ## Notes
 
-- HTTP integration tests use FastAPI `TestClient` and a test SQLite database.
+- HTTP integration tests use FastAPI `TestClient` and, by default, a temporary SQLite database.
+- Pass `--http-env-file /path/to/.env` to run the HTTP suite against the `DATABASE_URL` from a specific env file for explicit seeding or environment validation.
+- The env-backed mode is not isolated; its fixtures may create, update, or restore records in the target database.
 - Email delivery is patched/skipped in test mode so tests do not contact SMTP servers.
 - Pagination tests seed their dedicated data directly to keep setup fast and stable.
 - Coverage intentionally omits infrastructure adapters such as SMTP delivery and request/profiling/OTel middleware wrappers.

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from dotenv import dotenv_values
 from unittest.mock import patch
 
 import app.configs as app_configs
@@ -27,6 +28,81 @@ from tests.utils.basic_auth import get_basic_auth_header
 
 TEST_DATA_BASE_PATH = "tests/data/http/"
 BASE_URL = "http://testserver"
+HTTP_TEST_SETTING_NAMES = (
+    "DATABASE_URL",
+    "ENV",
+    "ENVIRONMENT",
+    "TESTING",
+    "DB_AUTO_CREATE",
+    "FRONTEND_URL",
+    "JWT_SECRET",
+)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--http-env-file",
+        action="store",
+        default=None,
+        help=(
+            "Use the provided env file for HTTP tests instead of the default isolated "
+            "temporary SQLite configuration."
+        ),
+    )
+
+
+def _apply_runtime_settings(overrides: dict[str, str]) -> None:
+    app_configs._resolve_settings.cache_clear()
+
+    for name, value in overrides.items():
+        os.environ[name] = value
+
+    settings.DATABASE_URL = overrides["DATABASE_URL"]
+    settings.ENVIRONMENT = overrides.get(
+        "ENVIRONMENT", overrides.get("ENV", settings.ENVIRONMENT)
+    )
+    settings.TESTING = overrides["TESTING"].lower() == "true"
+    settings.DB_AUTO_CREATE = overrides["DB_AUTO_CREATE"].lower() == "true"
+    settings.FRONTEND_URL = overrides["FRONTEND_URL"]
+    settings.JWT_SECRET = overrides["JWT_SECRET"]
+
+
+def _build_default_http_test_settings(db_path: Path) -> dict[str, str]:
+    return {
+        "DATABASE_URL": f"sqlite:///{db_path}",
+        "ENV": "testing",
+        "ENVIRONMENT": "testing",
+        "TESTING": "true",
+        "DB_AUTO_CREATE": "true",
+        "FRONTEND_URL": "https://frontend.example.com/reset-password",
+        "JWT_SECRET": "testing-secret-key-with-at-least-32-bytes",
+    }
+
+
+def _load_http_test_env_file(env_file: str) -> dict[str, str]:
+    env_path = Path(env_file).expanduser().resolve()
+    if not env_path.exists():
+        raise pytest.UsageError(f"--http-env-file not found: {env_path}")
+
+    loaded = {
+        key: str(value)
+        for key, value in dotenv_values(env_path).items()
+        if value is not None
+    }
+    if "DATABASE_URL" not in loaded:
+        raise pytest.UsageError(
+            f"--http-env-file must define DATABASE_URL: {env_path}"
+        )
+
+    loaded.setdefault("ENV", loaded.get("ENVIRONMENT", "testing"))
+    loaded.setdefault("ENVIRONMENT", loaded.get("ENV", "testing"))
+    loaded.setdefault("TESTING", "true")
+    loaded.setdefault("DB_AUTO_CREATE", "true")
+    loaded.setdefault(
+        "FRONTEND_URL", "https://frontend.example.com/reset-password"
+    )
+    loaded.setdefault("JWT_SECRET", "testing-secret-key-with-at-least-32-bytes")
+    return loaded
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -50,27 +126,22 @@ def test_runtime_guards():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup_database():
+def setup_database(pytestconfig):
     """
     Setup a clean database for the test session.
-    Forces the application to use a test-specific database file.
+    By default this uses a test-specific database file.
+    Passing --http-env-file uses that env file instead.
     """
+    original_env = {name: os.environ.get(name) for name in HTTP_TEST_SETTING_NAMES}
     db_dir = Path(tempfile.mkdtemp(prefix="userverse-http-tests-"))
     db_path = db_dir / "test.db"
-
-    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
-    os.environ["ENV"] = "testing"
-    os.environ["TESTING"] = "true"
-    os.environ["DB_AUTO_CREATE"] = "true"
-    os.environ["FRONTEND_URL"] = "https://frontend.example.com/reset-password"
-    os.environ["JWT_SECRET"] = "testing-secret-key-with-at-least-32-bytes"
-    app_configs._resolve_settings.cache_clear()
-    settings.DATABASE_URL = f"sqlite:///{db_path}"
-    settings.ENVIRONMENT = "testing"
-    settings.TESTING = True
-    settings.DB_AUTO_CREATE = True
-    settings.FRONTEND_URL = "https://frontend.example.com/reset-password"
-    settings.JWT_SECRET = "testing-secret-key-with-at-least-32-bytes"
+    env_file = pytestconfig.getoption("--http-env-file")
+    runtime_settings = (
+        _load_http_test_env_file(env_file)
+        if env_file
+        else _build_default_http_test_settings(db_path)
+    )
+    _apply_runtime_settings(runtime_settings)
 
     default_db = DatabaseSessionManager()
     session_manager._default_db = default_db
@@ -92,9 +163,14 @@ def setup_database():
             delattr(settings, setting_name)
         except AttributeError:
             pass
-    if db_path.exists():
+    for name, original_value in original_env.items():
+        if original_value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = original_value
+    if not env_file and db_path.exists():
         db_path.unlink()
-    if db_dir.exists():
+    if not env_file and db_dir.exists():
         db_dir.rmdir()
 
 

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -20,6 +20,7 @@ from app.models.user.user import UserReadModel
 from app.configs import settings
 from app.repository.database.session_manager import DatabaseSessionManager
 from app.repository.database.tables import AssociationUserCompany, Company, Role, User
+from app.repository.database.tables import CompanyRole
 import app.repository.database.session_manager as session_manager
 from app.utils.hash_password import hash_password
 from tests.utils.basic_auth import get_basic_auth_header
@@ -143,7 +144,13 @@ def _get_role_row(company_id: UUID, name: str):
     try:
         return (
             session.query(Role)
-            .filter_by(company_id=company_id, name=name, _closed_at=None)
+            .join(CompanyRole, CompanyRole.role_id == Role.id)
+            .filter(
+                CompanyRole.company_id == company_id,
+                CompanyRole._closed_at.is_(None),
+                Role.name == name,
+                Role._closed_at.is_(None),
+            )
             .first()
         )
     finally:
@@ -235,22 +242,13 @@ async def _create_company_if_missing(
             }
 
             for default_role in CompanyDefaultRoles:
-                role_row = (
-                    session.query(Role)
-                    .filter_by(company_id=company_row.id, name=default_role.name_value)
-                    .one_or_none()
-                )
-                if role_row is None:
-                    session.add(
-                        Role(
-                            company_id=company_row.id,
-                            name=default_role.name_value,
-                            description=default_role.description,
-                        )
+                if not _get_role_row(company_row.id, default_role.name_value):
+                    Role.create(
+                        session,
+                        company_id=company_row.id,
+                        name=default_role.name_value,
+                        description=default_role.description,
                     )
-                else:
-                    role_row.description = default_role.description
-                    role_row._closed_at = None
 
             owner_row = session.query(User).filter_by(email=owner_email.lower()).one()
             owner_link = (
@@ -259,15 +257,17 @@ async def _create_company_if_missing(
                 .one_or_none()
             )
             if owner_link is None:
-                session.add(
-                    AssociationUserCompany(
-                        company_id=company_row.id,
-                        user_id=owner_row.id,
-                        role_name=CompanyDefaultRoles.OWNER.name_value,
-                    )
+                AssociationUserCompany.create(
+                    session,
+                    company_id=company_row.id,
+                    user_id=owner_row.id,
+                    role_name=CompanyDefaultRoles.OWNER.name_value,
                 )
             else:
-                owner_link.role_name = CompanyDefaultRoles.OWNER.name_value
+                owner_role = Role.role_belongs_to_company(
+                    session, company_row.id, CompanyDefaultRoles.OWNER.name_value
+                )
+                owner_link.role_id = owner_role["id"]
                 owner_link._closed_at = None
 
             session.commit()
@@ -301,11 +301,7 @@ async def _create_role_if_missing(
 
     session = session_manager.session_local()
     try:
-        role_row = (
-            session.query(Role)
-            .filter_by(company_id=company_id, name=role_payload["name"])
-            .one_or_none()
-        )
+        role_row = _get_role_row(company_id, role_payload["name"])
         if role_row is not None:
             role_row.description = role_payload["description"]
             role_row._closed_at = None
@@ -572,19 +568,13 @@ def seed_pagination_state():
 
         for company_id in company_ids:
             for default_role in CompanyDefaultRoles:
-                role_row = (
-                    session.query(Role)
-                    .filter_by(company_id=company_id, name=default_role.name_value)
-                    .one_or_none()
-                )
-                if role_row is None:
-                    role_row = Role(
+                if not _get_role_row(company_id, default_role.name_value):
+                    Role.create(
+                        session,
                         company_id=company_id,
                         name=default_role.name_value,
+                        description=default_role.description,
                     )
-                    session.add(role_row)
-                role_row.description = default_role.description
-                role_row._closed_at = None
             session.commit()
 
         custom_roles = [
@@ -592,21 +582,13 @@ def seed_pagination_state():
             ("Client", "Client role with access to client-specific features."),
         ]
         for role_name, description in custom_roles:
-            role_row = (
-                session.query(Role)
-                .filter_by(company_id=company_ids[0], name=role_name)
-                .one_or_none()
-            )
-            if role_row is None:
-                role_row = Role(
+            if not _get_role_row(company_ids[0], role_name):
+                Role.create(
+                    session,
                     company_id=company_ids[0],
                     name=role_name,
                     description=description,
                 )
-                session.add(role_row)
-            else:
-                role_row.description = description
-                role_row._closed_at = None
         session.commit()
 
         for company_id in company_ids:
@@ -616,14 +598,17 @@ def seed_pagination_state():
                 .one_or_none()
             )
             if owner_link is None:
-                owner_link = AssociationUserCompany(
+                owner_link = AssociationUserCompany.create(
+                    session,
                     company_id=company_id,
                     user_id=owner_row.id,
                     role_name=owner_role_name,
                 )
-                session.add(owner_link)
             else:
-                owner_link.role_name = owner_role_name
+                owner_role = Role.role_belongs_to_company(
+                    session, company_id, owner_role_name
+                )
+                owner_link.role_id = owner_role["id"]
                 owner_link._closed_at = None
             session.commit()
 
@@ -678,15 +663,15 @@ def seed_pagination_state():
                 .one_or_none()
             )
             if existing_link is None:
-                session.add(
-                    AssociationUserCompany(
-                        company_id=company_id,
-                        user_id=user_id,
-                        role_name=role_name,
-                    )
+                AssociationUserCompany.create(
+                    session,
+                    company_id=company_id,
+                    user_id=user_id,
+                    role_name=role_name,
                 )
             else:
-                existing_link.role_name = role_name
+                role = Role.role_belongs_to_company(session, company_id, role_name)
+                existing_link.role_id = role["id"]
                 existing_link._closed_at = None
             session.commit()
 

--- a/tests/database/test_a_user.py
+++ b/tests/database/test_a_user.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.exc import IntegrityError
 from app.repository.database.tables import User
 from app.repository.database.base_model import RecordNotFoundError
 from app.models.user.response_messages import UserResponseMessages
@@ -118,6 +119,25 @@ def test_create_user_rejects_duplicate_email(test_session, test_user_data):
         exc_info.value.detail["message"]
         == UserResponseMessages.USER_ALREADY_EXISTS.value
     )
+
+
+def test_create_user_reraises_non_duplicate_integrity_error(test_session, monkeypatch):
+    repository = UserRepository(test_session)
+    repository.db_session.rollback = lambda: None
+
+    def _raise_integrity(**kwargs):
+        raise IntegrityError("insert", {}, Exception("other integrity error"))
+
+    monkeypatch.setattr(repository, "create", _raise_integrity)
+
+    with pytest.raises(IntegrityError):
+        repository.create_user(
+            {
+                "email": "user@example.com",
+                "password": "secret",
+                "first_name": "User",
+            }
+        )
 
 
 def test_get_refresh_token_version_raises_when_user_missing(test_session):

--- a/tests/database/test_association_extra.py
+++ b/tests/database/test_association_extra.py
@@ -1,4 +1,5 @@
 from uuid import UUID, uuid4
+from types import SimpleNamespace
 
 import pytest
 
@@ -136,3 +137,11 @@ def test_unlink_user_soft_deletes_link_and_records_removed_by_metadata(
     assert unlinked._closed_at is not None
     assert unlinked.primary_meta_data["removed_by"]["id"] == str(removed_by.id)
     assert unlinked.primary_meta_data["removed_by"]["email"] == removed_by.email
+
+
+def test_role_name_property_prefers_loaded_role_name():
+    association = AssociationUserCompany()
+    association.__dict__["role"] = SimpleNamespace(name="Viewer")
+    association.secondary_meta_data = {"_legacy_role_name": "Legacy"}
+
+    assert association.role_name == "Viewer"

--- a/tests/database/test_base_model_extra.py
+++ b/tests/database/test_base_model_extra.py
@@ -42,6 +42,18 @@ def test_update_by_filters_missing_record_raises_value_error(test_session):
         )
 
 
+def test_update_by_filters_updates_existing_record(test_session, test_user_data):
+    created = User.create(test_session, **test_user_data["create_user"])
+
+    updated = User.update_by_filters(
+        test_session,
+        filters={"email": created["email"]},
+        first_name="Updated",
+    )
+
+    assert updated["first_name"] == "Updated"
+
+
 def test_delete_missing_record_raises_record_not_found(test_session):
     with pytest.raises(RecordNotFoundError):
         User.delete(test_session, 999)

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock
 
 from app.models.company.company import CompanyQueryParamsModel
 from app.repository.company import CompanyRepository
@@ -75,3 +76,19 @@ def test_company_repository_get_user_companies_supports_description_filter(
     )
 
     assert [company.email for company in result.records] == ["one@example.com"]
+
+
+def test_company_repository_ensure_default_roles_updates_description(monkeypatch):
+    session = Mock()
+    repository = CompanyRepository(session)
+    role = Role(name="Owner", description="Old role")
+    query = Mock()
+    query.filter.return_value.one_or_none.side_effect = [role, None, None]
+    session.query.return_value = query
+    session.commit = Mock()
+
+    default_roles = repository._ensure_default_roles()
+
+    assert role.description == "Full access to manage users and data"
+    assert default_roles["Owner"] is role
+    session.commit.assert_called_once()

--- a/tests/database/test_company_role_repository_unit.py
+++ b/tests/database/test_company_role_repository_unit.py
@@ -36,6 +36,15 @@ def _role_obj(name: str = "Viewer", description: str = "Read only"):
     return SimpleNamespace(id=uuid4(), name=name, description=description, _closed_at=None)
 
 
+def _role_model(name: str = "Viewer", description: str = "Read only") -> Role:
+    return Role(id=uuid4(), name=name, description=description)
+
+
+def test_role_repository_requires_session():
+    with pytest.raises(TypeError, match="requires a database session"):
+        RoleRepository()
+
+
 def test_role_repository_create_role_success(monkeypatch):
     repository = RoleRepository(session=Mock())
     created = _role_obj()
@@ -57,6 +66,14 @@ def test_role_repository_create_role_success(monkeypatch):
     assert result == expected
 
 
+def test_role_repository_to_read_model_serializes_id():
+    role = _role_model()
+
+    result = RoleRepository._to_read_model(role)
+
+    assert result.id == str(role.id)
+
+
 def test_role_repository_create_role_wraps_integrity_error(monkeypatch):
     repository = RoleRepository(session=Mock())
     repository.db_session.rollback = Mock()
@@ -74,6 +91,23 @@ def test_role_repository_create_role_wraps_integrity_error(monkeypatch):
 
     assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_ALREADY_EXISTS.value
     repository.db_session.rollback.assert_called_once()
+
+
+def test_role_repository_create_role_wraps_generic_error(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    monkeypatch.setattr(
+        repository,
+        "create",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(AppError) as exc_info:
+        repository.create_role(
+            RoleCreateModel(name="Viewer", description="Read only"),
+            _acting_user(),
+        )
+
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_CREATION_FAILED.value
 
 
 def test_role_repository_update_role_global_and_company_paths(monkeypatch):
@@ -115,6 +149,75 @@ def test_role_repository_update_role_global_and_company_paths(monkeypatch):
     assert updated_global.description == "New"
     assert updated_company.name == "Company Viewer"
     assert updated_company.description == "Company"
+
+
+def test_role_repository_ensure_role_helpers(monkeypatch):
+    role = _role_model()
+    repository = RoleRepository(session=Mock())
+    monkeypatch.setattr(repository, "get_role_record", lambda role_id: None)
+
+    with pytest.raises(AppError) as exc_info:
+        repository.ensure_role_exists(uuid4())
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_NOT_FOUND.value
+
+    monkeypatch.setattr(repository, "get_role_by_name", lambda name: None)
+    with pytest.raises(AppError) as exc_info:
+        repository.ensure_role_by_name("Missing")
+    assert exc_info.value.detail["message"] == "Failed to add user to the company. Please verify the input."
+
+    monkeypatch.setattr(repository, "get_role_by_name", lambda name: role)
+    assert repository.ensure_role_by_name("Viewer") is role
+
+    companyless = RoleRepository(session=Mock())
+    monkeypatch.setattr(companyless, "ensure_role_by_name", lambda name: role)
+    assert companyless.ensure_role_belongs_to_company("Viewer") is role
+
+    company_repo = RoleRepository(session=Mock(), company_id=uuid4())
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_role_name_assigned",
+        lambda self, name: role,
+    )
+    assert company_repo.ensure_role_belongs_to_company("Viewer") is role
+
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_role_name_assigned",
+        lambda self, name: SimpleNamespace(),
+    )
+    with pytest.raises(AppError) as exc_info:
+        company_repo.ensure_role_belongs_to_company("Missing")
+    assert exc_info.value.detail["message"] == "Failed to add user to the company. Please verify the input."
+
+
+def test_role_repository_update_role_error_paths(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    repository.db_session.rollback = Mock()
+    monkeypatch.setattr(repository, "get_role_record", lambda role_id: None)
+
+    with pytest.raises(AppError) as exc_info:
+        repository.update_role(uuid4(), RoleUpdateModel(name="Renamed", description=None))
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    company_repo = RoleRepository(session=Mock(), company_id=uuid4())
+    company_repo.db_session.rollback = Mock()
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_role_name_assigned",
+        lambda self, name: None,
+    )
+    with pytest.raises(AppError) as exc_info:
+        company_repo.update_role("Missing", RoleUpdateModel(name=None, description="x"))
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    broken_repo = RoleRepository(session=Mock())
+    broken_repo.db_session.rollback = Mock()
+    broken_repo.db_session.commit = Mock(side_effect=RuntimeError("commit failed"))
+    monkeypatch.setattr(broken_repo, "get_role_record", lambda role_id: _role_obj())
+    with pytest.raises(AppError) as exc_info:
+        broken_repo.update_role(uuid4(), RoleUpdateModel(name="X", description=None))
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+    broken_repo.db_session.rollback.assert_called_once()
 
 
 def test_role_repository_delete_role_branches(monkeypatch):
@@ -182,6 +285,19 @@ def test_role_repository_delete_role_branches(monkeypatch):
     success = success_repository.delete_role(active_role.id, deleted_by)
     assert success["message"] == f"Role '{active_role.name}' deleted successfully."
 
+    missing_args_repository = RoleRepository(session=Mock())
+    missing_args_repository.db_session.rollback = Mock()
+    with pytest.raises(AppError) as exc_info:
+        missing_args_repository.delete_role()
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value
+
+    missing_role_repository = RoleRepository(session=Mock())
+    missing_role_repository.db_session.rollback = Mock()
+    monkeypatch.setattr(missing_role_repository, "get_role_record", lambda role_id: None)
+    with pytest.raises(AppError) as exc_info:
+        missing_role_repository.delete_role(uuid4(), deleted_by)
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value
+
 
 def test_company_role_assignment_assign_role_to_companies_skips_existing_and_adds_new(monkeypatch):
     session = Mock()
@@ -232,6 +348,131 @@ def test_company_role_assignment_assign_role_to_companies_skips_existing_and_add
     assert updated_assignments == [company_ids[1]]
 
 
+def test_company_role_assignment_get_roles_and_ensure_assigned_branches(monkeypatch):
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    monkeypatch.setattr(
+        repository,
+        "paginate",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("bad query")),
+    )
+    with pytest.raises(AppError) as exc_info:
+        repository.get_company_roles(
+            SimpleNamespace(name="View", description="Read", page=1, limit=10)
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_NOT_FOUND.value
+
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: None)
+    with pytest.raises(AppError) as exc_info:
+        repository.ensure_role_assigned(uuid4())
+    assert exc_info.value.detail["message"] == "Failed to add user to the company. Please verify the input."
+
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: object())
+    assert repository.ensure_role_assigned(uuid4()) is not None
+
+    success_repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    success_query = Mock()
+    success_query.filter.return_value = success_query
+    monkeypatch.setattr(
+        success_repository.db_session,
+        "query",
+        lambda model: success_query,
+    )
+    captured = {}
+    monkeypatch.setattr(
+        success_repository,
+        "paginate",
+        lambda query, **kwargs: captured.update(kwargs) or {"records": [], "pagination": {"current_page": 1, "limit": 10, "total_records": 0, "total_pages": 0}},
+    )
+    result = success_repository.get_company_roles(
+        SimpleNamespace(name="View", description="Read", page=1, limit=10)
+    )
+    assert result["records"] == []
+    assert captured["page"] == 1
+
+
+def test_company_role_assignment_name_lookup_helpers(monkeypatch):
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    role = _role_model()
+
+    query = Mock()
+    query.join.return_value.filter.return_value.one_or_none.return_value = role
+    repository.db_session.query.return_value = query
+    assert repository.ensure_role_name_assigned("Viewer") is role
+    assert repository.get_role_name_assigned("Viewer") is role
+
+    query.join.return_value.filter.return_value.one_or_none.return_value = None
+    with pytest.raises(AppError) as exc_info:
+        repository.ensure_role_name_assigned("Missing")
+    assert exc_info.value.detail["message"] == "Failed to add user to the company. Please verify the input."
+
+
+def test_company_role_assignment_update_company_role_and_assign_role(monkeypatch):
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    repository.db_session.refresh = Mock()
+    repository.db_session.rollback = Mock()
+    role = _role_model(name="Viewer", description="Old")
+    monkeypatch.setattr(repository, "get_role_name_assigned", lambda name: role)
+    monkeypatch.setattr(
+        RoleRepository,
+        "_to_read_model",
+        staticmethod(lambda role: RoleReadModel(id=str(role.id), name=role.name, description=role.description)),
+    )
+
+    updated = repository.update_company_role(
+        "Viewer",
+        RoleUpdateModel(name="Viewer+", description="New"),
+    )
+    assert updated.name == "Viewer+"
+    assert updated.description == "New"
+
+    monkeypatch.setattr(repository, "get_role_name_assigned", lambda name: None)
+    with pytest.raises(AppError) as exc_info:
+        repository.update_company_role(
+            "Missing",
+            RoleUpdateModel(name=None, description="New"),
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    assign_repo = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    monkeypatch.setattr(assign_repo, "get_assignment", lambda role_id: None)
+    monkeypatch.setattr(assign_repo, "create", lambda **kwargs: SimpleNamespace())
+    update_calls = []
+    monkeypatch.setattr(
+        assign_repo,
+        "update_json_field",
+        lambda assignment, **kwargs: update_calls.append(kwargs["key"]),
+    )
+    assigned = assign_repo.assign_role(_role_model(), _acting_user())
+    assert assigned.id is not None
+    assert update_calls == ["assigned_by"]
+
+    monkeypatch.setattr(assign_repo, "get_assignment", lambda role_id: object())
+    with pytest.raises(AppError) as exc_info:
+        assign_repo.assign_role(_role_model(), _acting_user())
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_CREATION_FAILED.value
+
+
+def test_role_repository_get_roles_applies_name_and_description_filters(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    query = Mock()
+    query.filter.return_value = query
+    monkeypatch.setattr(repository, "_base_query", lambda: query)
+    captured = {}
+    monkeypatch.setattr(
+        repository,
+        "paginate",
+        lambda query_obj, **kwargs: captured.update(kwargs) or {"records": [], "pagination": {}},
+    )
+
+    result = repository.get_roles(
+        SimpleNamespace(name="View", description="Read", page=1, limit=10)
+    )
+
+    assert result["records"] == []
+    assert query.filter.call_count == 3
+    assert captured["page"] == 1
+
+
 def test_company_role_assignment_unassign_role_branches(monkeypatch):
     repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
 
@@ -263,3 +504,57 @@ def test_company_role_assignment_unassign_role_branches(monkeypatch):
 
     result = repository.unassign_role(uuid4())
     assert result == {"message": "Role unassigned successfully."}
+
+
+def test_company_role_assignment_reassign_and_delete_role_branches(monkeypatch):
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    deleted_by = _acting_user()
+
+    with pytest.raises(AppError) as exc_info:
+        repository.reassign_and_delete_role(
+            RoleDeleteModel(
+                role_name_to_delete="Client",
+                replacement_role_name="Client",
+            ),
+            deleted_by,
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    delete_role = _role_model(name="Client")
+    monkeypatch.setattr(
+        repository,
+        "get_role_name_assigned",
+        lambda name: delete_role if name == "Client" else None,
+    )
+    with pytest.raises(AppError) as exc_info:
+        repository.reassign_and_delete_role(
+            RoleDeleteModel(
+                role_name_to_delete="Client",
+                replacement_role_name="Viewer",
+            ),
+            deleted_by,
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    replacement_role = _role_model(name="Viewer")
+    user_link = SimpleNamespace(role_id=delete_role.id)
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    repository.db_session.add = Mock()
+    repository.db_session.commit = Mock()
+    repository.db_session.query.return_value.filter.return_value.all.return_value = [user_link]
+    monkeypatch.setattr(
+        repository,
+        "get_role_name_assigned",
+        lambda name: delete_role if name == "Client" else replacement_role,
+    )
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: None)
+    with pytest.raises(AppError) as exc_info:
+        repository.reassign_and_delete_role(
+            RoleDeleteModel(
+                role_name_to_delete="Client",
+                replacement_role_name="Viewer",
+            ),
+            deleted_by,
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+    assert user_link.role_id == replacement_role.id

--- a/tests/database/test_company_role_repository_unit.py
+++ b/tests/database/test_company_role_repository_unit.py
@@ -1,0 +1,265 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.company.response_messages import CompanyRoleResponseMessages
+from app.models.company.roles import (
+    RoleAssignCompaniesModel,
+    RoleCreateModel,
+    RoleDeleteModel,
+    RoleReadModel,
+    RoleUpdateModel,
+)
+from app.models.user.account_status import UserAccountStatus
+from app.models.user.user import UserReadModel
+from app.repository.company_role import CompanyRoleAssignmentRepository, RoleRepository
+from app.repository.database.tables import Role
+from app.utils.app_error import AppError
+
+
+def _acting_user() -> UserReadModel:
+    return UserReadModel(
+        id=uuid4(),
+        email="admin@example.com",
+        first_name="Admin",
+        last_name="User",
+        phone_number="+27123456789",
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=False,
+    )
+
+
+def _role_obj(name: str = "Viewer", description: str = "Read only"):
+    return SimpleNamespace(id=uuid4(), name=name, description=description, _closed_at=None)
+
+
+def test_role_repository_create_role_success(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    created = _role_obj()
+    expected = RoleReadModel(id=str(created.id), name=created.name, description=created.description)
+
+    monkeypatch.setattr(repository, "create", lambda **kwargs: created)
+    monkeypatch.setattr(
+        repository,
+        "update_json_field",
+        lambda role, **kwargs: role,
+    )
+    monkeypatch.setattr(RoleRepository, "_to_read_model", staticmethod(lambda role: expected))
+
+    result = repository.create_role(
+        RoleCreateModel(name="Viewer", description="Read only"),
+        _acting_user(),
+    )
+
+    assert result == expected
+
+
+def test_role_repository_create_role_wraps_integrity_error(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    repository.db_session.rollback = Mock()
+
+    def _raise_integrity(**kwargs):
+        raise IntegrityError("insert", {}, Exception("duplicate"))
+
+    monkeypatch.setattr(repository, "create", _raise_integrity)
+
+    with pytest.raises(AppError) as exc_info:
+        repository.create_role(
+            RoleCreateModel(name="Viewer", description="Read only"),
+            _acting_user(),
+        )
+
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_ALREADY_EXISTS.value
+    repository.db_session.rollback.assert_called_once()
+
+
+def test_role_repository_update_role_global_and_company_paths(monkeypatch):
+    repository = RoleRepository(session=Mock())
+    repository.db_session.refresh = Mock()
+    global_role = _role_obj(name="Viewer", description="Old")
+    company_id = uuid4()
+    company_repository = RoleRepository(session=Mock(), company_id=company_id)
+    company_repository.db_session.refresh = Mock()
+    company_role = _role_obj(name="Viewer", description="Old")
+
+    monkeypatch.setattr(repository, "get_role_record", lambda role_id: global_role)
+    monkeypatch.setattr(
+        company_repository,
+        "_to_read_model",
+        staticmethod(lambda role: RoleReadModel(id=str(role.id), name=role.name, description=role.description)),
+    )
+    monkeypatch.setattr(
+        RoleRepository,
+        "_to_read_model",
+        staticmethod(lambda role: RoleReadModel(id=str(role.id), name=role.name, description=role.description)),
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_role_name_assigned",
+        lambda self, name: company_role,
+    )
+
+    updated_global = repository.update_role(
+        global_role.id,
+        RoleUpdateModel(name="Viewer+", description="New"),
+    )
+    updated_company = company_repository.update_role(
+        "Viewer",
+        RoleUpdateModel(name="Company Viewer", description="Company"),
+    )
+
+    assert updated_global.name == "Viewer+"
+    assert updated_global.description == "New"
+    assert updated_company.name == "Company Viewer"
+    assert updated_company.description == "Company"
+
+
+def test_role_repository_delete_role_branches(monkeypatch):
+    deleted_by = _acting_user()
+
+    with pytest.raises(AppError) as exc_info:
+        RoleRepository(session=Mock()).delete_role(
+            payload=RoleDeleteModel(
+                role_name_to_delete="Client",
+                replacement_role_name="Viewer",
+            ),
+            deleted_by=deleted_by,
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    company_repository = RoleRepository(session=Mock(), company_id=uuid4())
+    with pytest.raises(AppError) as exc_info:
+        company_repository.delete_role(
+            payload=RoleDeleteModel(
+                role_name_to_delete="Client",
+                replacement_role_name="Viewer",
+            ),
+        )
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+
+    monkeypatch.setattr(
+        Role,
+        "delete_role_and_reassign_users",
+        lambda **kwargs: {"message": "deleted", "users_reassigned": 2},
+    )
+    result = company_repository.delete_role(
+        payload=RoleDeleteModel(
+            role_name_to_delete="Client",
+            replacement_role_name="Viewer",
+        ),
+        deleted_by=deleted_by,
+    )
+    assert result["users_reassigned"] == 2
+
+    active_role = _role_obj(name="Viewer")
+    global_repository = RoleRepository(session=Mock())
+    global_repository.db_session.add = Mock()
+    global_repository.db_session.commit = Mock()
+    global_repository.db_session.rollback = Mock()
+    monkeypatch.setattr(global_repository, "get_role_record", lambda role_id: active_role)
+    monkeypatch.setattr(global_repository, "update_json_field", lambda role, **kwargs: role)
+    blocked_query = Mock()
+    blocked_query.filter.return_value.count.return_value = 1
+    global_repository.db_session.query.return_value = blocked_query
+
+    with pytest.raises(AppError) as exc_info:
+        global_repository.delete_role(active_role.id, deleted_by)
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value
+
+    success_repository = RoleRepository(session=Mock())
+    success_repository.db_session.add = Mock()
+    success_repository.db_session.commit = Mock()
+    success_repository.db_session.rollback = Mock()
+    monkeypatch.setattr(success_repository, "get_role_record", lambda role_id: active_role)
+    monkeypatch.setattr(success_repository, "update_json_field", lambda role, **kwargs: role)
+    clear_query = Mock()
+    clear_query.filter.return_value.count.return_value = 0
+    success_repository.db_session.query.return_value = clear_query
+
+    success = success_repository.delete_role(active_role.id, deleted_by)
+    assert success["message"] == f"Role '{active_role.name}' deleted successfully."
+
+
+def test_company_role_assignment_assign_role_to_companies_skips_existing_and_adds_new(monkeypatch):
+    session = Mock()
+    assigned_by = _acting_user()
+    role = _role_obj()
+    company_ids = [str(uuid4()), str(uuid4())]
+    created_assignments: list[tuple[str, str]] = []
+    updated_assignments: list[str] = []
+
+    def _get_assignment(self, role_id):
+        return object() if self.company_id == uuid4_obj else None
+
+    uuid4_obj = uuid4(company_ids[0]) if False else None
+
+    first_company = company_ids[0]
+
+    def _patched_get_assignment(self, role_id):
+        return object() if str(self.company_id) == first_company else None
+
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_assignment",
+        _patched_get_assignment,
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "create",
+        lambda self, **kwargs: created_assignments.append(
+            (str(kwargs["company_id"]), str(kwargs["role_id"]))
+        )
+        or SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "update_json_field",
+        lambda self, assignment, **kwargs: updated_assignments.append(str(self.company_id)),
+    )
+
+    repository = CompanyRoleAssignmentRepository(uuid4(), session)
+    result = repository.assign_role_to_companies(
+        role=role,
+        payload=RoleAssignCompaniesModel(company_ids=company_ids),
+        assigned_by=assigned_by,
+    )
+
+    assert result == {"role_id": str(role.id), "company_ids": [company_ids[1]]}
+    assert created_assignments == [(company_ids[1], str(role.id))]
+    assert updated_assignments == [company_ids[1]]
+
+
+def test_company_role_assignment_unassign_role_branches(monkeypatch):
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: None)
+    with pytest.raises(AppError) as exc_info:
+        repository.unassign_role(uuid4())
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_NOT_FOUND.value
+
+    assignment = SimpleNamespace(_closed_at=None)
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    repository.db_session.add = Mock()
+    repository.db_session.commit = Mock()
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: assignment)
+    blocked_query = Mock()
+    blocked_query.filter.return_value.count.return_value = 1
+    repository.db_session.query.return_value = blocked_query
+
+    with pytest.raises(AppError) as exc_info:
+        repository.unassign_role(uuid4())
+    assert exc_info.value.detail["message"] == CompanyRoleResponseMessages.ROLE_DELETION_FAILED.value
+
+    repository = CompanyRoleAssignmentRepository(uuid4(), Mock())
+    repository.db_session.add = Mock()
+    repository.db_session.commit = Mock()
+    monkeypatch.setattr(repository, "get_assignment", lambda role_id: assignment)
+    clear_query = Mock()
+    clear_query.filter.return_value.count.return_value = 0
+    repository.db_session.query.return_value = clear_query
+
+    result = repository.unassign_role(uuid4())
+    assert result == {"message": "Role unassigned successfully."}

--- a/tests/database/test_role_extra.py
+++ b/tests/database/test_role_extra.py
@@ -79,6 +79,27 @@ def test_update_role_updates_description_when_provided(
     assert updated["description"] == "Updated admin description"
 
 
+def test_update_role_updates_name_when_provided(
+    test_session, test_company_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["viewer_role"]["name"],
+        description=test_role_data["viewer_role"]["description"],
+    )
+
+    updated = Role.update_role(
+        test_session,
+        company["id"],
+        role["name"],
+        new_name="Read Only",
+    )
+
+    assert updated["name"] == "Read Only"
+
+
 def test_update_role_json_field_rejects_missing_role(test_session):
     company_id = uuid4()
     with pytest.raises(
@@ -128,6 +149,82 @@ def test_delete_role_and_reassign_users_rejects_same_replacement_name(test_sessi
     with pytest.raises(ValueError, match="Cannot replace a role with itself."):
         Role.delete_role_and_reassign_users(
             test_session, uuid4(), "Admin", "Admin", _deleted_by_user()
+        )
+
+
+def test_delete_by_filters_soft_deletes_company_assignment(
+    test_session, test_company_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["viewer_role"]["name"],
+        description=test_role_data["viewer_role"]["description"],
+    )
+
+    deleted = Role.delete_by_filters(
+        test_session,
+        filters={"company_id": company["id"], "name": role["name"]},
+    )
+
+    assert "deleted" in deleted["message"]
+
+
+def test_update_and_delete_by_filters_fall_back_without_company_scope(
+    test_session, test_role_data
+):
+    created = Role.create(
+        test_session,
+        name="Global Viewer",
+        description=test_role_data["viewer_role"]["description"],
+    )
+
+    updated = Role.update_by_filters(
+        test_session,
+        filters={"name": created["name"]},
+        description="Updated globally",
+    )
+    assert updated["description"] == "Updated globally"
+
+    deleted = Role.delete_by_filters(
+        test_session,
+        filters={"name": created["name"]},
+    )
+    assert "deleted" in deleted["message"]
+
+
+def test_update_json_field_updates_company_scoped_role(
+    test_session, test_company_data, test_role_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+    role = Role.create(
+        test_session,
+        company_id=company["id"],
+        name=test_role_data["viewer_role"]["name"],
+        description=test_role_data["viewer_role"]["description"],
+    )
+
+    updated = Role.update_json_field(
+        test_session,
+        company["id"],
+        role["name"],
+        "primary_meta_data",
+        "source",
+        "tests",
+    )
+
+    assert updated.primary_meta_data["source"] == "tests"
+
+
+def test_delete_role_and_reassign_users_rejects_missing_target_role_immediately(
+    test_session, test_company_data
+):
+    company = Company.create(test_session, **test_company_data["company_one"])
+
+    with pytest.raises(ValueError, match="Role 'Missing' not found."):
+        Role.delete_role_and_reassign_users(
+            test_session, company["id"], "Missing", "Viewer", _deleted_by_user()
         )
 
 

--- a/tests/database/test_session_manager.py
+++ b/tests/database/test_session_manager.py
@@ -14,8 +14,8 @@ def test_session_manager_uses_sqlite_engine_for_sqlite_urls(monkeypatch):
         lambda bind: None,
     )
     monkeypatch.setattr(
-        "app.repository.database.session_manager.DatabaseSessionManager._tables_exist",
-        lambda self: False,
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "missing",
     )
     monkeypatch.setattr(settings, "DATABASE_URL", "sqlite:///./development.db")
     monkeypatch.setattr(settings, "DB_AUTO_CREATE", True)
@@ -38,8 +38,8 @@ def test_session_manager_uses_static_pool_for_in_memory_sqlite(monkeypatch):
         lambda bind: None,
     )
     monkeypatch.setattr(
-        "app.repository.database.session_manager.DatabaseSessionManager._tables_exist",
-        lambda self: False,
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "missing",
     )
     monkeypatch.setattr(settings, "DATABASE_URL", "sqlite:///:memory:")
     monkeypatch.setattr(settings, "DB_AUTO_CREATE", True)
@@ -68,8 +68,8 @@ def test_session_manager_creates_non_sqlite_database_when_missing(monkeypatch):
         lambda bind: None,
     )
     monkeypatch.setattr(
-        "app.repository.database.session_manager.DatabaseSessionManager._tables_exist",
-        lambda self: False,
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "missing",
     )
     monkeypatch.setattr(settings, "DATABASE_URL", "postgresql://db.example/test")
     monkeypatch.setattr(settings, "DB_AUTO_CREATE", True)
@@ -98,8 +98,8 @@ def test_session_manager_does_not_create_database_when_auto_create_disabled(
         lambda url: created.append(url),
     )
     monkeypatch.setattr(
-        "app.repository.database.session_manager.DatabaseSessionManager._tables_exist",
-        lambda self: False,
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "missing",
     )
     monkeypatch.setattr(settings, "DATABASE_URL", "postgresql://db.example/test")
     monkeypatch.setattr(settings, "DB_AUTO_CREATE", False)
@@ -122,8 +122,8 @@ def test_session_manager_raises_when_schema_missing_and_auto_create_disabled(
         "app.repository.database.session_manager.database_exists", lambda url: True
     )
     monkeypatch.setattr(
-        "app.repository.database.session_manager.DatabaseSessionManager._tables_exist",
-        lambda self: False,
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "missing",
     )
     monkeypatch.setattr(settings, "DATABASE_URL", "postgresql://db.example/test")
     monkeypatch.setattr(settings, "DB_AUTO_CREATE", False)
@@ -135,6 +135,50 @@ def test_session_manager_raises_when_schema_missing_and_auto_create_disabled(
         assert "run Alembic migrations before startup" in str(exc)
     else:
         raise AssertionError("Expected DatabaseSessionManager to require migrations")
+
+
+def test_session_manager_raises_on_partial_schema(monkeypatch):
+    monkeypatch.setattr(
+        "app.repository.database.session_manager.create_engine",
+        lambda url, **kwargs: "engine",
+    )
+    monkeypatch.setattr(settings, "DATABASE_URL", "sqlite:///./development.db")
+    monkeypatch.setattr(settings, "DB_AUTO_CREATE", True)
+
+    monkeypatch.setattr(
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "partial",
+    )
+
+    try:
+        DatabaseSessionManager()
+    except RuntimeError as exc:
+        assert "incompatible with current models" in str(exc)
+    else:
+        raise AssertionError("Expected DatabaseSessionManager to reject partial schema")
+
+
+def test_session_manager_raises_on_incompatible_schema(monkeypatch):
+    monkeypatch.setattr(
+        "app.repository.database.session_manager.create_engine",
+        lambda url, **kwargs: "engine",
+    )
+    monkeypatch.setattr(settings, "DATABASE_URL", "sqlite:///./development.db")
+    monkeypatch.setattr(settings, "DB_AUTO_CREATE", True)
+
+    monkeypatch.setattr(
+        "app.repository.database.session_manager.DatabaseSessionManager._table_state",
+        lambda self: "incompatible",
+    )
+
+    try:
+        DatabaseSessionManager()
+    except RuntimeError as exc:
+        assert "incompatible with current models" in str(exc)
+    else:
+        raise AssertionError(
+            "Expected DatabaseSessionManager to reject incompatible schema"
+        )
 
 
 def test_session_local_uses_default_db_session_object(monkeypatch):

--- a/tests/database/test_session_manager.py
+++ b/tests/database/test_session_manager.py
@@ -1,6 +1,8 @@
+import pytest
 from app.configs import settings
 from app.repository.database.session_manager import DatabaseSessionManager
 from sqlalchemy.pool import StaticPool
+from unittest.mock import Mock
 
 
 def test_session_manager_uses_sqlite_engine_for_sqlite_urls(monkeypatch):
@@ -209,3 +211,57 @@ def test_get_engine_uses_default_db_engine(monkeypatch):
     from app.repository.database.session_manager import get_engine
 
     assert get_engine() is fake_engine
+
+
+def test_table_state_and_schema_helpers():
+    manager = DatabaseSessionManager.__new__(DatabaseSessionManager)
+    manager.expected_tables = ("role", "company_role")
+    manager.expected_columns = {
+        "role": {"id", "name"},
+        "company_role": {"company_id", "role_id"},
+    }
+    manager.forbidden_columns = {
+        "role": {"company_id"},
+        "company_role": set(),
+    }
+    manager.engine = object()
+
+    partial_inspector = Mock()
+    partial_inspector.has_table.side_effect = lambda name: name == "role"
+
+    incompatible_inspector = Mock()
+    incompatible_inspector.has_table.return_value = True
+    incompatible_inspector.get_columns.side_effect = lambda table_name: (
+        [{"name": "id"}, {"name": "name"}, {"name": "company_id"}]
+        if table_name == "role"
+        else [{"name": "company_id"}]
+    )
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(
+            "app.repository.database.session_manager.inspect",
+            lambda engine: partial_inspector,
+        )
+        assert manager._table_state() == "partial"
+
+        monkeypatch.setattr(
+            "app.repository.database.session_manager.inspect",
+            lambda engine: incompatible_inspector,
+        )
+        assert manager._table_state() == "incompatible"
+        assert manager._tables_exist() is False
+        assert manager._schema_matches_models(incompatible_inspector) is False
+        assert manager.get_engine() is manager.engine
+    finally:
+        monkeypatch.undo()
+
+
+def test_schema_matches_models_rejects_missing_required_columns():
+    manager = DatabaseSessionManager.__new__(DatabaseSessionManager)
+    manager.expected_columns = {"role": {"id", "name"}}
+    manager.forbidden_columns = {"role": set()}
+    inspector = Mock()
+    inspector.get_columns.return_value = [{"name": "id"}]
+
+    assert manager._schema_matches_models(inspector) is False

--- a/tests/utils/test_lightweight_coverage.py
+++ b/tests/utils/test_lightweight_coverage.py
@@ -1581,6 +1581,69 @@ def test_role_service_happy_path_branches(monkeypatch):
     assert company_roles.records[0].id == str(role_id)
 
 
+def test_role_service_update_role_additional_falsey_paths(monkeypatch):
+    acting_user = UserReadModel(
+        id=uuid4(),
+        email="admin@example.com",
+        first_name="Admin",
+        last_name="User",
+        phone_number="+27123456789",
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=False,
+    )
+    context = SharedContext(db_session=object(), user=acting_user)
+    service = RoleService(context)
+    company_id = uuid4()
+
+    monkeypatch.setattr(service, "_ensure_company_manager", lambda cid: None)
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "update_company_role",
+        lambda self, name, payload: None,
+    )
+
+    with pytest.raises(AppError) as exc_info:
+        service.update_company_role(
+            company_id,
+            "Viewer",
+            RoleUpdateModel(name=None, description="Updated"),
+        )
+    assert (
+        exc_info.value.detail["message"]
+        == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+    )
+
+
+def test_role_service_update_role_keyword_success(monkeypatch):
+    acting_user = UserReadModel(
+        id=uuid4(),
+        email="admin@example.com",
+        first_name="Admin",
+        last_name="User",
+        phone_number="+27123456789",
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=False,
+    )
+    context = SharedContext(db_session=object(), user=acting_user)
+    service = RoleService(context)
+    role = RoleReadModel(id=str(uuid4()), name="Viewer", description="Updated")
+
+    monkeypatch.setattr(RoleRepository, "update_role", lambda self, role_id, payload: role)
+
+    assert (
+        service.update_role(role_id=uuid4(), payload=RoleUpdateModel(name=None, description="Updated"))
+        == role
+    )
+
+    monkeypatch.setattr(RoleRepository, "update_role", lambda self, role_id, payload: None)
+    with pytest.raises(AppError) as exc_info:
+        service.update_role(uuid4(), RoleUpdateModel(name=None, description="Updated"))
+    assert (
+        exc_info.value.detail["message"]
+        == CompanyRoleResponseMessages.ROLE_UPDATE_FAILED.value
+    )
+
+
 def test_company_repository_wraps_integrity_error(monkeypatch):
     repository = CompanyRepository(Mock())
     repository.db_session.rollback = Mock()

--- a/tests/utils/test_lightweight_coverage.py
+++ b/tests/utils/test_lightweight_coverage.py
@@ -13,10 +13,12 @@ from pydantic import ValidationError
 import app.services.mailer as mailer_module
 import app.exceptions as exceptions_module
 import app.main as main_module
+from app.api.routers import roles as global_roles_router
+from app.api.routers.company import roles as company_roles_router
 from app.configs import Settings, _SettingsProxy
 import app.repository.database.session_manager as session_manager
 from app.repository.company import CompanyRepository
-from app.repository.company_role import RoleRepository
+from app.repository.company_role import CompanyRoleAssignmentRepository, RoleRepository
 from app.services.company.company import CompanyService
 from app.services.company.role import RoleService
 from app.services.company.user import CompanyUserService
@@ -28,10 +30,14 @@ from app.models.company.response_messages import (
     CompanyUserResponseMessages,
 )
 from app.models.company.roles import (
+    RoleAssignCompaniesModel,
     RoleCreateModel,
+    RoleDeleteModel,
     RoleQueryParamsModel,
+    RoleReadModel,
     RoleUpdateModel,
 )
+from app.models.generic_pagination import PaginatedResponse
 from app.models.user.response_messages import UserResponseMessages
 from app.models.user.user import UserReadModel
 from app.services.user.basic_auth import UserBasicAuthService
@@ -1379,6 +1385,200 @@ def test_role_service_branches_for_falsey_repository_results(monkeypatch):
         exc_info.value.detail["message"]
         == CompanyRoleResponseMessages.ROLE_CREATION_FAILED.value
     )
+
+
+def test_global_role_router_wrappers(monkeypatch):
+    acting_user = types.SimpleNamespace(id=uuid4())
+    common = types.SimpleNamespace(user=acting_user, session=object())
+    role_id = uuid4()
+    role = RoleReadModel(id=str(role_id), name="Viewer", description="Read only")
+    paginated = PaginatedResponse[RoleReadModel](
+        records=[role],
+        pagination={
+            "current_page": 1,
+            "limit": 10,
+            "total_records": 1,
+            "total_pages": 1,
+        },
+    )
+
+    monkeypatch.setattr(RoleService, "create_role", lambda self, payload: role)
+    monkeypatch.setattr(RoleService, "get_roles", lambda self, payload: paginated)
+    monkeypatch.setattr(RoleService, "update_role", lambda self, **kwargs: role)
+    monkeypatch.setattr(
+        RoleService,
+        "delete_global_role",
+        lambda self, role_id: {"message": "Role deleted"},
+    )
+    monkeypatch.setattr(
+        RoleService,
+        "assign_role_to_companies",
+        lambda self, role_id, payload: {
+            "role_id": str(role_id),
+            "company_ids": payload.company_ids,
+        },
+    )
+
+    create_response = global_roles_router.create_role_api(
+        RoleCreateModel(name="Viewer", description="Read only"),
+        common=common,
+    )
+    assert create_response.status_code == 201
+
+    get_response = global_roles_router.get_roles_api(
+        query_params=RoleQueryParamsModel(limit=10, page=1),
+        common=common,
+    )
+    assert get_response.status_code == 200
+
+    update_response = global_roles_router.update_role_api(
+        role_id=role_id,
+        payload=RoleUpdateModel(name="Viewer+", description="Updated"),
+        common=common,
+    )
+    assert update_response.status_code == 200
+
+    delete_response = global_roles_router.delete_role_api(role_id=role_id, common=common)
+    assert delete_response.status_code == 200
+
+    assign_response = global_roles_router.assign_role_to_companies_api(
+        role_id=role_id,
+        payload=RoleAssignCompaniesModel(company_ids=[str(uuid4())]),
+        common=common,
+    )
+    assert assign_response.status_code == 201
+
+
+def test_company_role_router_assignment_wrappers(monkeypatch):
+    acting_user = types.SimpleNamespace(id=uuid4())
+    common = types.SimpleNamespace(user=acting_user, session=object())
+    company_id = uuid4()
+    role_id = uuid4()
+    role = RoleReadModel(id=str(role_id), name="Viewer", description="Read only")
+
+    monkeypatch.setattr(
+        RoleService, "assign_role_to_company", lambda self, company_id, role_id: role
+    )
+    monkeypatch.setattr(
+        RoleService,
+        "unassign_role",
+        lambda self, company_id, role_id: {"message": "Role unassigned successfully."},
+    )
+
+    assign_response = company_roles_router.assign_role_to_company_api(
+        company_id=company_id,
+        role_id=role_id,
+        common=common,
+    )
+    assert assign_response.status_code == 201
+
+    unassign_response = company_roles_router.unassign_role_from_company_api(
+        company_id=company_id,
+        role_id=role_id,
+        common=common,
+    )
+    assert unassign_response.status_code == 200
+
+
+def test_role_service_happy_path_branches(monkeypatch):
+    acting_user = UserReadModel(
+        id=uuid4(),
+        email="admin@example.com",
+        first_name="Admin",
+        last_name="User",
+        phone_number="+27123456789",
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=False,
+    )
+    context = SharedContext(db_session=object(), user=acting_user)
+    service = RoleService(context)
+    company_id = uuid4()
+    role_id = uuid4()
+    role = RoleReadModel(id=str(role_id), name="Viewer", description="Read only")
+
+    monkeypatch.setattr(service, "_ensure_company_manager", lambda cid: None)
+    monkeypatch.setattr(
+        RoleRepository,
+        "get_roles",
+        lambda self, payload: {
+            "records": [{"id": role_id, "name": "Viewer", "description": "Read only"}],
+            "pagination": {
+                "current_page": 1,
+                "limit": 10,
+                "total_records": 1,
+                "total_pages": 1,
+            },
+        },
+    )
+    monkeypatch.setattr(RoleRepository, "delete_role", lambda self, role_id, user: {"message": "deleted"})
+    monkeypatch.setattr(RoleRepository, "ensure_role_exists", lambda self, role_id: types.SimpleNamespace(id=role_id))
+    monkeypatch.setattr(
+        RoleRepository,
+        "get_role_by_name",
+        lambda self, name: types.SimpleNamespace(id=role_id, name=name, description="Read only"),
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "assign_role",
+        lambda self, role, user: RoleReadModel(id=str(role.id), name="Viewer", description="Read only"),
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "assign_role_to_companies",
+        lambda self, role, payload, user: {"role_id": str(role.id), "company_ids": payload.company_ids},
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "unassign_role",
+        lambda self, role_id: {"message": "Role unassigned successfully."},
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "reassign_and_delete_role",
+        lambda self, payload, user: {"message": "deleted", "users_reassigned": 1},
+    )
+    monkeypatch.setattr(
+        CompanyRoleAssignmentRepository,
+        "get_company_roles",
+        lambda self, payload: {
+            "records": [{"id": role_id, "name": "Viewer", "description": "Read only"}],
+            "pagination": {
+                "current_page": 1,
+                "limit": 10,
+                "total_records": 1,
+                "total_pages": 1,
+            },
+        },
+    )
+
+    paginated = service.get_roles(RoleQueryParamsModel(limit=10, page=1))
+    assert paginated.records[0].name == "Viewer"
+
+    assert service.delete_global_role(role_id)["message"] == "deleted"
+    assert service.assign_role_to_company(company_id, role_id).id == str(role_id)
+    assert service.assign_role_to_companies(
+        role_id, RoleAssignCompaniesModel(company_ids=[])
+    ) == {"role_id": str(role_id), "company_ids": []}
+    assert service.assign_role_to_companies(
+        role_id, RoleAssignCompaniesModel(company_ids=[str(company_id)])
+    ) == {"role_id": str(role_id), "company_ids": [str(company_id)]}
+    assert (
+        service.create_role_for_company(
+            RoleCreateModel(name="Viewer", description="Read only"),
+            company_id,
+        ).id
+        == str(role_id)
+    )
+    assert service.unassign_role(company_id, role_id)["message"] == "Role unassigned successfully."
+    assert service.delete_role(
+        RoleDeleteModel(role_name_to_delete="Client", replacement_role_name="Viewer"),
+        company_id,
+    )["users_reassigned"] == 1
+    company_roles = service.get_company_roles(
+        RoleQueryParamsModel(limit=10, page=1),
+        company_id,
+    )
+    assert company_roles.records[0].id == str(role_id)
 
 
 def test_company_repository_wraps_integrity_error(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -538,6 +538,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -548,6 +549,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -558,6 +560,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1880,7 +1883,7 @@ wheels = [
 
 [[package]]
 name = "userverse"
-version = "0.6.34"
+version = "0.6.35"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
**Description**
## Summary
This PR decouples roles from companies so roles can exist independently and be assigned to one or many companies.

Previously, roles were stored as company-owned records keyed by `(company_id, name)`. This change moves roles to a standalone shared model, introduces explicit company-role assignment, and updates company-user role membership to reference shared roles by `role_id`.

## What Changed
- Refactored `role` into a standalone shared entity with its own `id`
- Added `company_role` join model/table wiring in the ORM layer
- Updated company-user membership to store `role_id` instead of `role_name`
- Added global role endpoints under `/roles`
- Added company-role assignment endpoints
- Kept legacy company-scoped role flows working for compatibility:
  - `POST /company/{company_id}/role`
  - `PATCH /company/{company_id}/role/{name}`
  - `DELETE /company/{company_id}/role`
  - `GET /company/{company_id}/roles`
- Updated company creation to assign default shared roles instead of creating company-local role rows
- Updated test fixtures/helpers to work with the shared-role model

## Behavior Changes
- A role is now a shared global definition
- The same role can be assigned to multiple companies
- Updating a shared role updates that definition everywhere it is assigned
- Company-user role assignment now validates that the role is assigned to the target company

## Compatibility Notes
- Existing company-scoped role routes were preserved as compatibility wrappers where needed
- Legacy tests expecting company-scoped behavior were updated or supported via compatibility logic

## Testing
Verified with:
```bash
uv run pytest tests/database/test_c_role.py tests/database/test_e_association.py tests/api/http/c_company_roles/test_d_create_role.py tests/api/http/c_company_roles/test_e_update_role.py tests/api/http/c_company_roles/test_f_delete_role.py tests/api/http/c_company_roles/test_g_get_roles.py tests/api/http/d_company_users/test_h_get_company_users.py tests/api/http/d_company_users/test_i_get_user_companies.py tests/api/http/d_company_users/test_j_add_user_to_company.py tests/api/http/d_company_users/test_l_update_user_role.py tests/api/http/test_pagination_regressions.py -q
```

Result:
```bash
57 passed in 45.44s
```