### PR TITLE
Return structured role objects in company user responses

### DIFF
--- a/app/api/routers/roles.py
+++ b/app/api/routers/roles.py
@@ -23,7 +23,15 @@ router = APIRouter()
 tag = UserverseApiTag.COMPANY_ROLE_MANAGEMENT.name
 
 
-@router.post("/roles", tags=[tag], status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/roles",
+    tags=[tag],
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        201: {"model": GenericResponseModel[RoleReadModel]},
+        400: {"model": AppErrorResponseModel},
+    },
+)
 def create_role_api(
     payload: RoleCreateModel,
     common: CommonJWTRouteDependencies = Depends(),
@@ -63,7 +71,15 @@ def get_roles_api(
     )
 
 
-@router.patch("/roles/{role_id}", tags=[tag], status_code=status.HTTP_200_OK)
+@router.patch(
+    "/roles/{role_id}",
+    tags=[tag],
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"model": GenericResponseModel[RoleReadModel]},
+        400: {"model": AppErrorResponseModel},
+    },
+)
 def update_role_api(
     role_id: UUID,
     payload: RoleUpdateModel,

--- a/app/api/routers/user/user_profile_routes.py
+++ b/app/api/routers/user/user_profile_routes.py
@@ -9,7 +9,7 @@ from app.utils.shared_context import SharedContext
 from app.models.tags import UserverseApiTag
 from app.models.user.response_messages import UserResponseMessages
 from app.models.user.user import UserReadModel, UserUpdateModel
-from app.models.company.company import CompanyQueryParamsModel, CompanyReadModel
+from app.models.company.company import CompanyQueryParamsModel, UserCompanyReadModel
 from app.models.company.response_messages import CompanyUserResponseMessages
 from app.models.generic_response import GenericResponseModel
 from app.models.generic_pagination import PaginatedResponse
@@ -89,7 +89,7 @@ def update_user_api(
 @router.get(
     "/companies",
     status_code=status.HTTP_200_OK,
-    response_model=GenericResponseModel[PaginatedResponse[CompanyReadModel]],
+    response_model=GenericResponseModel[PaginatedResponse[UserCompanyReadModel]],
 )
 def get_user_companies_api(
     params: CompanyQueryParamsModel = Depends(),

--- a/app/models/company/company.py
+++ b/app/models/company/company.py
@@ -2,6 +2,7 @@ from typing import Optional
 from uuid import UUID
 
 from app.models.company.address import CompanyAddressModel
+from app.models.company.roles import RoleReadModel
 from pydantic import BaseModel, EmailStr, field_validator, Field
 from app.models.phone_number import validate_phone_number_format
 from app.models.generic_pagination import PaginationParams
@@ -17,6 +18,10 @@ class CompanyReadModel(BaseModel):
     )
     email: EmailStr
     address: Optional[CompanyAddressModel] = None
+
+
+class UserCompanyReadModel(CompanyReadModel):
+    role: RoleReadModel
 
 
 class CompanyUpdateModel(BaseModel):

--- a/app/models/company/roles.py
+++ b/app/models/company/roles.py
@@ -46,8 +46,9 @@ class RoleDeleteModel(BaseModel):
 
 class RoleReadModel(BaseModel):
     id: str | None = None
-    name: Optional[str]
-    description: Optional[str]
+    name: Optional[str] = None
+    description: Optional[str] = None
+    permissions: list[str] = Field(default_factory=list)
 
 
 class RoleAssignCompaniesModel(BaseModel):

--- a/app/models/company/user.py
+++ b/app/models/company/user.py
@@ -1,11 +1,10 @@
 from pydantic import BaseModel, EmailStr, Field
-from app.models.company.roles import CompanyDefaultRoles
+from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
 from app.models.user.user import UserReadModel
 
 
 class CompanyUserReadModel(UserReadModel):
-    role_id: str | None = None
-    role_name: str
+    role: RoleReadModel
 
 
 class CompanyUserAddModel(BaseModel):

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import status
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import contains_eager
 
 from app.models.company.address import CompanyAddressModel
 from app.models.company.company import (
@@ -10,9 +10,10 @@ from app.models.company.company import (
     CompanyQueryParamsModel,
     CompanyReadModel,
     CompanyUpdateModel,
+    UserCompanyReadModel,
 )
 from app.models.company.response_messages import CompanyResponseMessages
-from app.models.company.roles import CompanyDefaultRoles
+from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
 from app.models.generic_pagination import (
     PaginatedResponse,
     apply_pagination,
@@ -180,7 +181,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
 
     def get_user_companies(
         self, user_id: UUID, params: CompanyQueryParamsModel
-    ) -> PaginatedResponse[CompanyReadModel]:
+    ) -> PaginatedResponse[UserCompanyReadModel]:
         query = (
             self.db_session.query(AssociationUserCompany)
             .join(AssociationUserCompany.company)
@@ -204,7 +205,10 @@ class CompanyRepository(BaseSQLRepository[Company]):
 
         total = query.count()
         results = apply_pagination(
-            query.options(joinedload(AssociationUserCompany.company)),
+            query.options(
+                contains_eager(AssociationUserCompany.company),
+                contains_eager(AssociationUserCompany.role),
+            ),
             page=params.page,
             limit=params.limit,
             order_by=[
@@ -212,8 +216,18 @@ class CompanyRepository(BaseSQLRepository[Company]):
                 Company.id.asc(),
             ],
         ).all()
-        companies = [self._to_read_model(assoc.company) for assoc in results]
-        return PaginatedResponse[CompanyReadModel](
+        companies = [
+            UserCompanyReadModel(
+                **self._to_read_model(assoc.company).model_dump(),
+                role=RoleReadModel(
+                    id=str(assoc.role.id),
+                    name=assoc.role.name,
+                    description=assoc.role.description,
+                ),
+            )
+            for assoc in results
+        ]
+        return PaginatedResponse[UserCompanyReadModel](
             records=companies,
             pagination=build_pagination_meta(
                 total_records=total,

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -8,7 +8,7 @@ from app.models.company.response_messages import (
     CompanyResponseMessages,
     CompanyUserResponseMessages,
 )
-from app.models.company.roles import CompanyDefaultRoles
+from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
 from app.models.company.user import CompanyUserAddModel, CompanyUserReadModel
 from app.models.generic_pagination import (
     PaginatedResponse,
@@ -39,8 +39,11 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             phone_number=user.phone_number,
             status=metadata.get("status"),
             is_superuser=user.is_superuser,
-            role_id=str(role.id),
-            role_name=role.name,
+            role=RoleReadModel(
+                id=str(role.id),
+                name=role.name,
+                description=role.description,
+            ),
         )
 
     def is_user_linked_to_company(

--- a/app/services/company/user.py
+++ b/app/services/company/user.py
@@ -97,7 +97,7 @@ class CompanyUserService:
             invitee_name=f"{user.first_name or ''} {user.last_name or ''}".strip()
             or user.email,
             company_name=company.name,
-            role_name=user.role_name,
+            role_name=user.role.name,
         )
         return user
 

--- a/tests/api/http/c_company_roles/test_d_create_role.py
+++ b/tests/api/http/c_company_roles/test_d_create_role.py
@@ -1,4 +1,5 @@
 import pytest
+from uuid import uuid4
 
 pytestmark = pytest.mark.anyio
 # TODO: cases to add
@@ -18,7 +19,15 @@ async def test_a_create_company_one_roles_success(
     Test creating roles for a company successfully.
     """
     company_id = seed_companies["company_one"]
-    roles = test_company_data["roles"]
+    suffix = uuid4().hex
+    roles = {
+        key: {
+            **value,
+            "name": f"{value['name']}-{suffix}",
+            "description": f"{value['description']} ({suffix})",
+        }
+        for key, value in test_company_data["roles"].items()
+    }
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
 
     for role_key, role_value in roles.items():
@@ -37,6 +46,7 @@ async def test_a_create_company_one_roles_success(
         assert "data" in json_data
         assert json_data["data"]["name"] == role_value["name"]
         assert json_data["data"]["description"] == role_value["description"]
+        assert json_data["data"]["permissions"] == []
 
 
 async def test_a_create_company_two_roles_success(
@@ -46,7 +56,15 @@ async def test_a_create_company_two_roles_success(
     Test creating roles for a company successfully.
     """
     company_id = seed_companies["company_two"]
-    roles = test_company_data["roles"]
+    suffix = uuid4().hex
+    roles = {
+        key: {
+            **value,
+            "name": f"{value['name']}-{suffix}",
+            "description": f"{value['description']} ({suffix})",
+        }
+        for key, value in test_company_data["roles"].items()
+    }
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
 
     for role_key, role_value in roles.items():
@@ -65,6 +83,7 @@ async def test_a_create_company_two_roles_success(
         assert "data" in json_data
         assert json_data["data"]["name"] == role_value["name"]
         assert json_data["data"]["description"] == role_value["description"]
+        assert json_data["data"]["permissions"] == []
 
 
 async def test_b_create_company_roles_failure(
@@ -99,10 +118,23 @@ async def test_c_create_company_roles_failure(
     Test creating roles for a company failure. When the roles already exist
     """
     company_id = seed_companies["company_two"]
-    roles = test_company_data["roles"]
+    suffix = uuid4().hex
+    roles = {
+        key: {
+            **value,
+            "name": f"{value['name']}-{suffix}",
+            "description": f"{value['description']} ({suffix})",
+        }
+        for key, value in test_company_data["roles"].items()
+    }
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
 
     for role_key, role_value in roles.items():
+        first_response = await client.post(
+            f"/company/{company_id}/role", json=role_value, headers=headers
+        )
+        assert first_response.status_code in [200, 201], first_response.text
+
         response = await client.post(
             f"/company/{company_id}/role", json=role_value, headers=headers
         )

--- a/tests/api/http/c_company_roles/test_h_global_role_management.py
+++ b/tests/api/http/c_company_roles/test_h_global_role_management.py
@@ -33,6 +33,7 @@ async def test_superuser_can_manage_global_roles_and_bulk_assign(
 ):
     payload = _role_payload()
     created = await _create_global_role(client, login_token_superuser, payload)
+    assert created["permissions"] == []
     role_id = created["id"]
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
 
@@ -49,6 +50,7 @@ async def test_superuser_can_manage_global_roles_and_bulk_assign(
         update_response.json()["message"]
         == CompanyRoleResponseMessages.ROLE_UPDATED.value
     )
+    assert update_response.json()["data"]["permissions"] == []
 
     assign_response = await client.post(
         f"/roles/{role_id}/companies",
@@ -97,6 +99,7 @@ async def test_company_owner_cannot_manage_global_roles(
     )
 
     created = await _create_global_role(client, login_token_superuser, _role_payload())
+    assert created["permissions"] == []
     role_id = created["id"]
 
     update_response = await client.patch(
@@ -136,6 +139,7 @@ async def test_owner_can_assign_and_unassign_existing_role_for_company(
     client, login_token, login_token_superuser, seed_companies
 ):
     created = await _create_global_role(client, login_token_superuser, _role_payload())
+    assert created["permissions"] == []
     role_id = created["id"]
     company_id = seed_companies["company_one"]
     headers = {"Authorization": f"Bearer {login_token}"}
@@ -149,6 +153,7 @@ async def test_owner_can_assign_and_unassign_existing_role_for_company(
         assign_response.json()["message"]
         == CompanyRoleResponseMessages.ROLE_CREATION_SUCCESS.value
     )
+    assert assign_response.json()["data"]["permissions"] == []
 
     unassign_response = await client.delete(
         f"/company/{company_id}/roles/{role_id}",
@@ -165,6 +170,7 @@ async def test_non_manager_cannot_assign_or_unassign_company_role(
     client, login_token, login_token_user_two, login_token_superuser, seed_companies
 ):
     created = await _create_global_role(client, login_token_superuser, _role_payload())
+    assert created["permissions"] == []
     role_id = created["id"]
     company_id = seed_companies["company_one"]
 

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -700,7 +700,16 @@ def seed_pagination_state():
                 )
         session.commit()
 
-        for company_id in company_ids:
+        owner_company_role_names = [
+            owner_role_name,
+            administrator_role_name,
+            viewer_role_name,
+            owner_role_name,
+        ]
+        owner_company_roles = {}
+        for company_id, owner_company_role_name in zip(
+            company_ids, owner_company_role_names
+        ):
             owner_link = (
                 session.query(AssociationUserCompany)
                 .filter_by(company_id=company_id, user_id=owner_row.id)
@@ -711,15 +720,23 @@ def seed_pagination_state():
                     session,
                     company_id=company_id,
                     user_id=owner_row.id,
-                    role_name=owner_role_name,
+                    role_name=owner_company_role_name,
                 )
             else:
                 owner_role = Role.role_belongs_to_company(
-                    session, company_id, owner_role_name
+                    session, company_id, owner_company_role_name
                 )
                 owner_link.role_id = owner_role["id"]
                 owner_link._closed_at = None
             session.commit()
+            owner_role = Role.role_belongs_to_company(
+                session, company_id, owner_company_role_name
+            )
+            owner_company_roles[str(company_id)] = {
+                "id": str(owner_role["id"]),
+                "name": owner_company_role_name,
+                "description": owner_role["description"],
+            }
 
         user_ids = []
         for user_data in extra_users:
@@ -808,6 +825,7 @@ def seed_pagination_state():
             "role_company_id": company_ids[0],
             "users_company_id": company_ids[0],
             "user_company_ids": company_ids,
+            "owner_company_roles": owner_company_roles,
             "users": user_ids,
         }
     finally:

--- a/tests/api/http/d_company_users/test_h_get_company_users.py
+++ b/tests/api/http/d_company_users/test_h_get_company_users.py
@@ -96,6 +96,11 @@ async def test_get_users_for_company(
         records = json_data["data"]["records"]
         actual_emails = {user["email"] for user in records}
         assert actual_emails == expected_emails
+        for user in records:
+            assert "role_id" not in user
+            assert "role_name" not in user
+            assert set(user["role"]) == {"id", "name", "description", "permissions"}
+            assert user["role"]["permissions"] == []
         pagination = json_data["data"]["pagination"]
         assert pagination["limit"] == 10
         assert pagination["current_page"] == 1
@@ -107,3 +112,28 @@ async def test_get_users_for_company(
             json_data["detail"]["message"]
             == CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value
         )
+
+
+async def test_get_users_for_company_returns_nested_role_details(
+    client,
+    login_token,
+    seed_companies,
+    verify_both_users,
+):
+    response = await client.get(
+        f"/company/{seed_companies['company_one']}/users?limit=10&page=1",
+        headers={
+            "Authorization": f"Bearer {login_token}",
+            "accept": "application/json",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    record = response.json()["data"]["records"][0]
+    assert record["email"] == "user.one@email.com"
+    assert record["role"] == {
+        "id": record["role"]["id"],
+        "name": "Owner",
+        "description": "Full access to manage users and data",
+        "permissions": [],
+    }

--- a/tests/api/http/d_company_users/test_i_get_user_companies.py
+++ b/tests/api/http/d_company_users/test_i_get_user_companies.py
@@ -75,6 +75,11 @@ async def test_get_user_companies(
         }
         company_ids = {company["id"] for company in json_data["data"]["records"]}
         assert company_ids == expected_company_ids
+        for company in json_data["data"]["records"]:
+            assert company["role"]["id"]
+            assert company["role"]["name"] == "Owner"
+            assert company["role"]["description"]
+            assert company["role"]["permissions"] == []
 
         pagination = json_data["data"]["pagination"]
         assert pagination["limit"] == 10

--- a/tests/api/http/d_company_users/test_l_update_user_role.py
+++ b/tests/api/http/d_company_users/test_l_update_user_role.py
@@ -83,14 +83,16 @@ def _get_link_row(company_id: str, user_id: str):
 async def test_update_company_user_role_success(
     client, login_token, login_token_superuser
 ):
+    role_name = f"User-{uuid4().hex}"
+    role_description = "Standard user role for company-user role update tests."
     company_id = await _create_company(client, login_token)
     await _create_role(
         client,
         login_token_superuser,
         company_id,
         {
-            "name": "User",
-            "description": "Standard user role for company-user role update tests.",
+            "name": role_name,
+            "description": role_description,
         },
     )
     user_id = await _add_user_to_company(
@@ -99,7 +101,7 @@ async def test_update_company_user_role_success(
 
     response = await client.patch(
         f"/company/{company_id}/user/{user_id}",
-        json={"role": "User"},
+        json={"role": role_name},
         headers={"Authorization": f"Bearer {login_token}"},
     )
 
@@ -107,23 +109,29 @@ async def test_update_company_user_role_success(
     json_data = response.json()
     assert "data" in json_data
     assert json_data["data"]["id"] == user_id
-    assert json_data["data"]["role_name"] == "User"
+    assert json_data["data"]["role"] == {
+        "id": json_data["data"]["role"]["id"],
+        "name": role_name,
+        "description": role_description,
+        "permissions": [],
+    }
 
     link_row = _get_link_row(company_id, user_id)
     assert link_row is not None
-    assert link_row.role_name == "User"
+    assert link_row.role_name == role_name
 
 
 async def test_update_company_user_role_forbidden_for_non_admin(
     client, login_token, login_token_superuser, login_token_user_two
 ):
+    role_name = f"User-{uuid4().hex}"
     company_id = await _create_company(client, login_token)
     await _create_role(
         client,
         login_token_superuser,
         company_id,
         {
-            "name": "User",
+            "name": role_name,
             "description": "Standard user role for company-user role update tests.",
         },
     )
@@ -133,7 +141,7 @@ async def test_update_company_user_role_forbidden_for_non_admin(
 
     response = await client.patch(
         f"/company/{company_id}/user/{user_id}",
-        json={"role": "User"},
+        json={"role": role_name},
         headers={"Authorization": f"Bearer {login_token_user_two}"},
     )
 
@@ -164,13 +172,14 @@ async def test_update_company_user_role_rejects_unknown_role(client, login_token
 async def test_update_company_user_role_returns_not_found_for_missing_link(
     client, login_token, login_token_superuser
 ):
+    role_name = f"User-{uuid4().hex}"
     company_id = await _create_company(client, login_token)
     await _create_role(
         client,
         login_token_superuser,
         company_id,
         {
-            "name": "User",
+            "name": role_name,
             "description": "Standard user role for company-user role update tests.",
         },
     )
@@ -178,7 +187,7 @@ async def test_update_company_user_role_returns_not_found_for_missing_link(
 
     response = await client.patch(
         f"/company/{company_id}/user/{user_id}",
-        json={"role": "User"},
+        json={"role": role_name},
         headers={"Authorization": f"Bearer {login_token}"},
     )
 

--- a/tests/api/http/d_company_users/test_m_openapi_role_schema.py
+++ b/tests/api/http/d_company_users/test_m_openapi_role_schema.py
@@ -1,0 +1,26 @@
+from app.main import create_app
+
+
+def test_openapi_documents_nested_company_user_role_schema():
+    schema = create_app().openapi()
+
+    company_user_schema = schema["components"]["schemas"]["CompanyUserReadModel"]
+    role_schema = schema["components"]["schemas"]["RoleReadModel"]
+    users_get_schema = schema["paths"]["/company/{company_id}/users"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+
+    assert "role_id" not in company_user_schema["properties"]
+    assert "role_name" not in company_user_schema["properties"]
+    assert company_user_schema["properties"]["role"] == {
+        "$ref": "#/components/schemas/RoleReadModel"
+    }
+    assert role_schema["properties"]["permissions"] == {
+        "items": {"type": "string"},
+        "type": "array",
+        "title": "Permissions",
+    }
+    assert (
+        users_get_schema["$ref"]
+        == "#/components/schemas/GenericResponseModel_PaginatedResponse_CompanyUserReadModel__"
+    )

--- a/tests/api/http/d_company_users/test_m_openapi_role_schema.py
+++ b/tests/api/http/d_company_users/test_m_openapi_role_schema.py
@@ -5,14 +5,23 @@ def test_openapi_documents_nested_company_user_role_schema():
     schema = create_app().openapi()
 
     company_user_schema = schema["components"]["schemas"]["CompanyUserReadModel"]
+    user_company_schema = schema["components"]["schemas"]["UserCompanyReadModel"]
     role_schema = schema["components"]["schemas"]["RoleReadModel"]
     users_get_schema = schema["paths"]["/company/{company_id}/users"]["get"][
         "responses"
     ]["200"]["content"]["application/json"]["schema"]
+    user_companies_schema = schema["paths"]["/user/companies"]["get"]["responses"][
+        "200"
+    ]["content"]["application/json"]["schema"]
 
     assert "role_id" not in company_user_schema["properties"]
     assert "role_name" not in company_user_schema["properties"]
     assert company_user_schema["properties"]["role"] == {
+        "$ref": "#/components/schemas/RoleReadModel"
+    }
+    assert "role_id" not in user_company_schema["properties"]
+    assert "role_name" not in user_company_schema["properties"]
+    assert user_company_schema["properties"]["role"] == {
         "$ref": "#/components/schemas/RoleReadModel"
     }
     assert role_schema["properties"]["permissions"] == {
@@ -23,4 +32,8 @@ def test_openapi_documents_nested_company_user_role_schema():
     assert (
         users_get_schema["$ref"]
         == "#/components/schemas/GenericResponseModel_PaginatedResponse_CompanyUserReadModel__"
+    )
+    assert (
+        user_companies_schema["$ref"]
+        == "#/components/schemas/GenericResponseModel_PaginatedResponse_UserCompanyReadModel__"
     )

--- a/tests/api/http/test_pagination_regressions.py
+++ b/tests/api/http/test_pagination_regressions.py
@@ -85,3 +85,43 @@ async def test_get_user_companies_page_two_is_stable(client, seed_pagination_sta
         "current_page": 2,
         "total_pages": 2,
     }
+
+
+async def test_get_user_companies_returns_company_specific_roles(
+    client, seed_pagination_state
+):
+    headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
+
+    response = await client.get(
+        "/user/companies?limit=4&page=1",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    json_data = response.json()
+    records = json_data["data"]["records"]
+
+    assert [company["id"] for company in records] == [
+        str(company_id) for company_id in seed_pagination_state["user_company_ids"]
+    ]
+    for company in records:
+        expected_role = seed_pagination_state["owner_company_roles"][company["id"]]
+        assert company["name"].startswith("Pagination Company")
+        assert company["address"] == {
+            "street": "123 Pagination Road",
+            "city": "Johannesburg",
+            "state": "Gauteng",
+            "postal_code": "2000",
+            "country": "South Africa",
+        }
+        assert company["role"] == {
+            **expected_role,
+            "permissions": [],
+        }
+
+    assert json_data["data"]["pagination"] == {
+        "total_records": 4,
+        "limit": 4,
+        "current_page": 1,
+        "total_pages": 1,
+    }

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import Mock
 
+from sqlalchemy import event
+
 from app.models.company.company import CompanyQueryParamsModel
 from app.repository.company import CompanyRepository
 from app.repository.database.tables import AssociationUserCompany
@@ -76,6 +78,125 @@ def test_company_repository_get_user_companies_supports_description_filter(
     )
 
     assert [company.email for company in result.records] == ["one@example.com"]
+    assert result.records[0].role.name == "Owner"
+    assert result.records[0].role.permissions == []
+
+
+def test_company_repository_get_user_companies_returns_company_specific_roles(
+    test_session,
+):
+    user = User.create(
+        test_session,
+        email="multi-role-user@example.com",
+        password="secret",
+        first_name="Role",
+    )
+    company_one = Company.create(
+        test_session,
+        email="role-one@example.com",
+        name="Role One",
+        description="First role company",
+    )
+    company_two = Company.create(
+        test_session,
+        email="role-two@example.com",
+        name="Role Two",
+        description="Second role company",
+    )
+    owner_role = Role.create(
+        test_session,
+        company_id=company_one["id"],
+        name="Owner",
+        description="Owner role",
+    )
+    viewer_role = Role.create(
+        test_session,
+        company_id=company_two["id"],
+        name="Viewer",
+        description="Viewer role",
+    )
+    AssociationUserCompany.create(
+        test_session,
+        user_id=user["id"],
+        company_id=company_one["id"],
+        role_name="Owner",
+    )
+    AssociationUserCompany.create(
+        test_session,
+        user_id=user["id"],
+        company_id=company_two["id"],
+        role_name="Viewer",
+    )
+
+    result = CompanyRepository(test_session).get_user_companies(
+        user["id"],
+        CompanyQueryParamsModel(limit=10, page=1),
+    )
+
+    roles_by_email = {company.email: company.role for company in result.records}
+    assert roles_by_email["role-one@example.com"].model_dump() == {
+        "id": str(owner_role["id"]),
+        "name": "Owner",
+        "description": "Owner role",
+        "permissions": [],
+    }
+    assert roles_by_email["role-two@example.com"].model_dump() == {
+        "id": str(viewer_role["id"]),
+        "name": "Viewer",
+        "description": "Viewer role",
+        "permissions": [],
+    }
+
+
+def test_company_repository_get_user_companies_uses_fixed_select_count(test_session):
+    user = User.create(
+        test_session,
+        email="query-count-user@example.com",
+        password="secret",
+        first_name="Query",
+    )
+    roles = [
+        Role.create(
+            test_session,
+            company_id=Company.create(
+                test_session,
+                email=f"query-count-{index}@example.com",
+                name=f"Query Count {index}",
+                description=f"Query count company {index}",
+            )["id"],
+            name=role_name,
+            description=f"{role_name} role",
+        )
+        for index, role_name in enumerate(["Owner", "Administrator", "Viewer"], 1)
+    ]
+    for index, role in enumerate(roles, 1):
+        company = Company.get_company_by_email(
+            test_session, f"query-count-{index}@example.com"
+        )
+        AssociationUserCompany.create(
+            test_session,
+            user_id=user["id"],
+            company_id=company["id"],
+            role_id=role["id"],
+        )
+
+    select_statements = []
+
+    def record_select(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_statements.append(statement)
+
+    event.listen(test_session.bind, "before_cursor_execute", record_select)
+    try:
+        result = CompanyRepository(test_session).get_user_companies(
+            user["id"],
+            CompanyQueryParamsModel(limit=10, page=1),
+        )
+    finally:
+        event.remove(test_session.bind, "before_cursor_execute", record_select)
+
+    assert len(result.records) == 3
+    assert len(select_statements) == 2
 
 
 def test_company_repository_ensure_default_roles_updates_description(monkeypatch):

--- a/tests/utils/test_lightweight_coverage.py
+++ b/tests/utils/test_lightweight_coverage.py
@@ -716,7 +716,10 @@ def test_company_user_service_sends_company_invite(monkeypatch):
     added_company_user = type(
         "AddedCompanyUser",
         (),
-        {**added_user.model_dump(mode="json"), "role_name": "Viewer"},
+        {
+            **added_user.model_dump(mode="json"),
+            "role": type("Role", (), {"name": "Viewer"})(),
+        },
     )()
     company = type("Company", (), {"name": "Acme Co"})()
 


### PR DESCRIPTION
## Summary

Replace flattened company-user role fields with a nested `role` object and align shared role responses across the API.

This updates `GET /userverse/company/{company_id}/users` to return:

```json
{
  "role": {
    "id": "uuid",
    "name": "Owner",
    "description": "Full administrative access to the company.",
    "permissions": []
  }
}