### PR TITLE
Add user company role details

### DIFF
--- a/app/api/routers/user/user_profile_routes.py
+++ b/app/api/routers/user/user_profile_routes.py
@@ -9,7 +9,7 @@ from app.utils.shared_context import SharedContext
 from app.models.tags import UserverseApiTag
 from app.models.user.response_messages import UserResponseMessages
 from app.models.user.user import UserReadModel, UserUpdateModel
-from app.models.company.company import CompanyQueryParamsModel, CompanyReadModel
+from app.models.company.company import CompanyQueryParamsModel, UserCompanyReadModel
 from app.models.company.response_messages import CompanyUserResponseMessages
 from app.models.generic_response import GenericResponseModel
 from app.models.generic_pagination import PaginatedResponse
@@ -89,7 +89,7 @@ def update_user_api(
 @router.get(
     "/companies",
     status_code=status.HTTP_200_OK,
-    response_model=GenericResponseModel[PaginatedResponse[CompanyReadModel]],
+    response_model=GenericResponseModel[PaginatedResponse[UserCompanyReadModel]],
 )
 def get_user_companies_api(
     params: CompanyQueryParamsModel = Depends(),

--- a/app/models/company/company.py
+++ b/app/models/company/company.py
@@ -2,6 +2,7 @@ from typing import Optional
 from uuid import UUID
 
 from app.models.company.address import CompanyAddressModel
+from app.models.company.roles import RoleReadModel
 from pydantic import BaseModel, EmailStr, field_validator, Field
 from app.models.phone_number import validate_phone_number_format
 from app.models.generic_pagination import PaginationParams
@@ -17,6 +18,10 @@ class CompanyReadModel(BaseModel):
     )
     email: EmailStr
     address: Optional[CompanyAddressModel] = None
+
+
+class UserCompanyReadModel(CompanyReadModel):
+    role: RoleReadModel
 
 
 class CompanyUpdateModel(BaseModel):

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import status
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import contains_eager
 
 from app.models.company.address import CompanyAddressModel
 from app.models.company.company import (
@@ -10,9 +10,10 @@ from app.models.company.company import (
     CompanyQueryParamsModel,
     CompanyReadModel,
     CompanyUpdateModel,
+    UserCompanyReadModel,
 )
 from app.models.company.response_messages import CompanyResponseMessages
-from app.models.company.roles import CompanyDefaultRoles
+from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
 from app.models.generic_pagination import (
     PaginatedResponse,
     apply_pagination,
@@ -180,7 +181,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
 
     def get_user_companies(
         self, user_id: UUID, params: CompanyQueryParamsModel
-    ) -> PaginatedResponse[CompanyReadModel]:
+    ) -> PaginatedResponse[UserCompanyReadModel]:
         query = (
             self.db_session.query(AssociationUserCompany)
             .join(AssociationUserCompany.company)
@@ -204,7 +205,10 @@ class CompanyRepository(BaseSQLRepository[Company]):
 
         total = query.count()
         results = apply_pagination(
-            query.options(joinedload(AssociationUserCompany.company)),
+            query.options(
+                contains_eager(AssociationUserCompany.company),
+                contains_eager(AssociationUserCompany.role),
+            ),
             page=params.page,
             limit=params.limit,
             order_by=[
@@ -212,8 +216,18 @@ class CompanyRepository(BaseSQLRepository[Company]):
                 Company.id.asc(),
             ],
         ).all()
-        companies = [self._to_read_model(assoc.company) for assoc in results]
-        return PaginatedResponse[CompanyReadModel](
+        companies = [
+            UserCompanyReadModel(
+                **self._to_read_model(assoc.company).model_dump(),
+                role=RoleReadModel(
+                    id=str(assoc.role.id),
+                    name=assoc.role.name,
+                    description=assoc.role.description,
+                ),
+            )
+            for assoc in results
+        ]
+        return PaginatedResponse[UserCompanyReadModel](
             records=companies,
             pagination=build_pagination_meta(
                 total_records=total,

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -700,7 +700,16 @@ def seed_pagination_state():
                 )
         session.commit()
 
-        for company_id in company_ids:
+        owner_company_role_names = [
+            owner_role_name,
+            administrator_role_name,
+            viewer_role_name,
+            owner_role_name,
+        ]
+        owner_company_roles = {}
+        for company_id, owner_company_role_name in zip(
+            company_ids, owner_company_role_names
+        ):
             owner_link = (
                 session.query(AssociationUserCompany)
                 .filter_by(company_id=company_id, user_id=owner_row.id)
@@ -711,15 +720,23 @@ def seed_pagination_state():
                     session,
                     company_id=company_id,
                     user_id=owner_row.id,
-                    role_name=owner_role_name,
+                    role_name=owner_company_role_name,
                 )
             else:
                 owner_role = Role.role_belongs_to_company(
-                    session, company_id, owner_role_name
+                    session, company_id, owner_company_role_name
                 )
                 owner_link.role_id = owner_role["id"]
                 owner_link._closed_at = None
             session.commit()
+            owner_role = Role.role_belongs_to_company(
+                session, company_id, owner_company_role_name
+            )
+            owner_company_roles[str(company_id)] = {
+                "id": str(owner_role["id"]),
+                "name": owner_company_role_name,
+                "description": owner_role["description"],
+            }
 
         user_ids = []
         for user_data in extra_users:
@@ -808,6 +825,7 @@ def seed_pagination_state():
             "role_company_id": company_ids[0],
             "users_company_id": company_ids[0],
             "user_company_ids": company_ids,
+            "owner_company_roles": owner_company_roles,
             "users": user_ids,
         }
     finally:

--- a/tests/api/http/d_company_users/test_i_get_user_companies.py
+++ b/tests/api/http/d_company_users/test_i_get_user_companies.py
@@ -75,6 +75,11 @@ async def test_get_user_companies(
         }
         company_ids = {company["id"] for company in json_data["data"]["records"]}
         assert company_ids == expected_company_ids
+        for company in json_data["data"]["records"]:
+            assert company["role"]["id"]
+            assert company["role"]["name"] == "Owner"
+            assert company["role"]["description"]
+            assert company["role"]["permissions"] == []
 
         pagination = json_data["data"]["pagination"]
         assert pagination["limit"] == 10

--- a/tests/api/http/d_company_users/test_m_openapi_role_schema.py
+++ b/tests/api/http/d_company_users/test_m_openapi_role_schema.py
@@ -5,14 +5,23 @@ def test_openapi_documents_nested_company_user_role_schema():
     schema = create_app().openapi()
 
     company_user_schema = schema["components"]["schemas"]["CompanyUserReadModel"]
+    user_company_schema = schema["components"]["schemas"]["UserCompanyReadModel"]
     role_schema = schema["components"]["schemas"]["RoleReadModel"]
     users_get_schema = schema["paths"]["/company/{company_id}/users"]["get"][
         "responses"
     ]["200"]["content"]["application/json"]["schema"]
+    user_companies_schema = schema["paths"]["/user/companies"]["get"]["responses"][
+        "200"
+    ]["content"]["application/json"]["schema"]
 
     assert "role_id" not in company_user_schema["properties"]
     assert "role_name" not in company_user_schema["properties"]
     assert company_user_schema["properties"]["role"] == {
+        "$ref": "#/components/schemas/RoleReadModel"
+    }
+    assert "role_id" not in user_company_schema["properties"]
+    assert "role_name" not in user_company_schema["properties"]
+    assert user_company_schema["properties"]["role"] == {
         "$ref": "#/components/schemas/RoleReadModel"
     }
     assert role_schema["properties"]["permissions"] == {
@@ -23,4 +32,8 @@ def test_openapi_documents_nested_company_user_role_schema():
     assert (
         users_get_schema["$ref"]
         == "#/components/schemas/GenericResponseModel_PaginatedResponse_CompanyUserReadModel__"
+    )
+    assert (
+        user_companies_schema["$ref"]
+        == "#/components/schemas/GenericResponseModel_PaginatedResponse_UserCompanyReadModel__"
     )

--- a/tests/api/http/test_pagination_regressions.py
+++ b/tests/api/http/test_pagination_regressions.py
@@ -85,3 +85,43 @@ async def test_get_user_companies_page_two_is_stable(client, seed_pagination_sta
         "current_page": 2,
         "total_pages": 2,
     }
+
+
+async def test_get_user_companies_returns_company_specific_roles(
+    client, seed_pagination_state
+):
+    headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
+
+    response = await client.get(
+        "/user/companies?limit=4&page=1",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    json_data = response.json()
+    records = json_data["data"]["records"]
+
+    assert [company["id"] for company in records] == [
+        str(company_id) for company_id in seed_pagination_state["user_company_ids"]
+    ]
+    for company in records:
+        expected_role = seed_pagination_state["owner_company_roles"][company["id"]]
+        assert company["name"].startswith("Pagination Company")
+        assert company["address"] == {
+            "street": "123 Pagination Road",
+            "city": "Johannesburg",
+            "state": "Gauteng",
+            "postal_code": "2000",
+            "country": "South Africa",
+        }
+        assert company["role"] == {
+            **expected_role,
+            "permissions": [],
+        }
+
+    assert json_data["data"]["pagination"] == {
+        "total_records": 4,
+        "limit": 4,
+        "current_page": 1,
+        "total_pages": 1,
+    }

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import Mock
 
+from sqlalchemy import event
+
 from app.models.company.company import CompanyQueryParamsModel
 from app.repository.company import CompanyRepository
 from app.repository.database.tables import AssociationUserCompany
@@ -76,6 +78,125 @@ def test_company_repository_get_user_companies_supports_description_filter(
     )
 
     assert [company.email for company in result.records] == ["one@example.com"]
+    assert result.records[0].role.name == "Owner"
+    assert result.records[0].role.permissions == []
+
+
+def test_company_repository_get_user_companies_returns_company_specific_roles(
+    test_session,
+):
+    user = User.create(
+        test_session,
+        email="multi-role-user@example.com",
+        password="secret",
+        first_name="Role",
+    )
+    company_one = Company.create(
+        test_session,
+        email="role-one@example.com",
+        name="Role One",
+        description="First role company",
+    )
+    company_two = Company.create(
+        test_session,
+        email="role-two@example.com",
+        name="Role Two",
+        description="Second role company",
+    )
+    owner_role = Role.create(
+        test_session,
+        company_id=company_one["id"],
+        name="Owner",
+        description="Owner role",
+    )
+    viewer_role = Role.create(
+        test_session,
+        company_id=company_two["id"],
+        name="Viewer",
+        description="Viewer role",
+    )
+    AssociationUserCompany.create(
+        test_session,
+        user_id=user["id"],
+        company_id=company_one["id"],
+        role_name="Owner",
+    )
+    AssociationUserCompany.create(
+        test_session,
+        user_id=user["id"],
+        company_id=company_two["id"],
+        role_name="Viewer",
+    )
+
+    result = CompanyRepository(test_session).get_user_companies(
+        user["id"],
+        CompanyQueryParamsModel(limit=10, page=1),
+    )
+
+    roles_by_email = {company.email: company.role for company in result.records}
+    assert roles_by_email["role-one@example.com"].model_dump() == {
+        "id": str(owner_role["id"]),
+        "name": "Owner",
+        "description": "Owner role",
+        "permissions": [],
+    }
+    assert roles_by_email["role-two@example.com"].model_dump() == {
+        "id": str(viewer_role["id"]),
+        "name": "Viewer",
+        "description": "Viewer role",
+        "permissions": [],
+    }
+
+
+def test_company_repository_get_user_companies_uses_fixed_select_count(test_session):
+    user = User.create(
+        test_session,
+        email="query-count-user@example.com",
+        password="secret",
+        first_name="Query",
+    )
+    roles = [
+        Role.create(
+            test_session,
+            company_id=Company.create(
+                test_session,
+                email=f"query-count-{index}@example.com",
+                name=f"Query Count {index}",
+                description=f"Query count company {index}",
+            )["id"],
+            name=role_name,
+            description=f"{role_name} role",
+        )
+        for index, role_name in enumerate(["Owner", "Administrator", "Viewer"], 1)
+    ]
+    for index, role in enumerate(roles, 1):
+        company = Company.get_company_by_email(
+            test_session, f"query-count-{index}@example.com"
+        )
+        AssociationUserCompany.create(
+            test_session,
+            user_id=user["id"],
+            company_id=company["id"],
+            role_id=role["id"],
+        )
+
+    select_statements = []
+
+    def record_select(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_statements.append(statement)
+
+    event.listen(test_session.bind, "before_cursor_execute", record_select)
+    try:
+        result = CompanyRepository(test_session).get_user_companies(
+            user["id"],
+            CompanyQueryParamsModel(limit=10, page=1),
+        )
+    finally:
+        event.remove(test_session.bind, "before_cursor_execute", record_select)
+
+    assert len(result.records) == 3
+    assert len(select_statements) == 2
 
 
 def test_company_repository_ensure_default_roles_updates_description(monkeypatch):


### PR DESCRIPTION
## Summary

Adds the authenticated user’s company-specific role to each company returned by `GET /user/companies`.

## Changes

- Added `UserCompanyReadModel` with a nested `role` object.
- Populates role data from `AssociationUserCompany.role`.
- Returns role fields:
  - `id`
  - `name`
  - `description`
  - `permissions`
- Keeps `permissions` as an empty array for now.
- Uses eager loading for company and role relationships to avoid N+1 queries.
- Updates the `/user/companies` OpenAPI response schema.
- Adds repository, OpenAPI, and HTTP coverage for company-specific roles.

## Testing

Ran:

```bash
.venv/bin/pytest tests/database/test_company_extra.py -q
.venv/bin/pytest tests/api/http/d_company_users/test_m_openapi_role_schema.py -q
.venv/bin/python -m compileall app tests/database/test_company_extra.py tests/api/http/d_company_users/test_i_get_user_companies.py tests/api/http/test_pagination_regressions.py tests/api/http/d_company_users/test_m_openapi_role_schema.py -q