### PR TITLE
feat: add hybrid global/company RBAC and secure superuser bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Roles are modeled as a shared global catalog. Company membership in a role is re
 
 See the [Global and Company RBAC Guide](docs/role-permission-guide.md) for the permission model, authorization rules, API workflows, and examples.
 
+See the [Superuser Administration Guide](docs/superuser-administration.md) for
+the trusted offline bootstrap procedure and the planned secured promotion API.
+
 ### Configuration
 
 Runtime settings are loaded from environment variables and `.env` through `app.configs.Settings`. Important variables include:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Business logic lives in `app/services`. Services coordinate authorization checks
 
 ### Repository and Database Layer
 
-Repository classes live in `app/repository`. SQLAlchemy models and session management live under `app/repository/database`. The canonical tables are `User`, `Company`, `Role`, `CompanyRole`, and `AssociationUserCompany`.
+Repository classes live in `app/repository`. SQLAlchemy models and session management live under `app/repository/database`. The authorization schema includes users, companies, the global role catalog, global and company permissions, company-role links, company memberships, and direct platform role assignments.
 
 Roles are modeled as a shared global catalog. Company membership in a role is represented by `company_role`, and user assignments point at the shared role record through `association_user_company.role_id`.
+
+See the [Global and Company RBAC Guide](docs/role-permission-guide.md) for the permission model, authorization rules, API workflows, and examples.
 
 ### Configuration
 
@@ -153,7 +155,7 @@ uv run pytest tests/api/http -q --http-env-file /home/sandile/projects/pj-userve
 
 Use the env-backed mode carefully: it does not create an isolated temporary database, and the HTTP test fixtures may update or seed the target database.
 
-Coverage is generated with `pytest-cov` and written to `coverage_reports/coverage.xml`. The current CI threshold is `96%`.
+Coverage is generated with `pytest-cov` and written to `coverage_reports/coverage.xml`. The CI statement-coverage threshold is `100%`.
 
 See [tests/README.md](tests/README.md) and [docs/testing.md](docs/testing.md) for more detail.
 

--- a/alembic/versions/b7c2d4e6f809_add_hybrid_permission_rbac.py
+++ b/alembic/versions/b7c2d4e6f809_add_hybrid_permission_rbac.py
@@ -1,0 +1,153 @@
+"""Add hybrid global and company-scoped RBAC permissions.
+
+Revision ID: b7c2d4e6f809
+Revises: a4e8c1b7d2f9
+Create Date: 2026-08-07 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b7c2d4e6f809"
+down_revision: Union[str, None] = "a4e8c1b7d2f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _audit_columns() -> list[sa.Column]:
+    return [
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=False),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=False),
+    ]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "global_permission",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("description", sa.String(length=256), nullable=True),
+        *_audit_columns(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_table(
+        "company_permission",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("description", sa.String(length=256), nullable=True),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["company_id"],
+            ["company.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "company_id",
+            "id",
+            name="uq_company_permission_company_id_id",
+        ),
+        sa.UniqueConstraint(
+            "company_id",
+            "name",
+            name="uq_company_permission_company_name",
+        ),
+    )
+    op.create_table(
+        "role_global_permission",
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        sa.Column("global_permission_id", sa.Uuid(), nullable=False),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["global_permission_id"],
+            ["global_permission.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["role.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("role_id", "global_permission_id"),
+    )
+    op.create_table(
+        "company_role_permission",
+        sa.Column("company_id", sa.Uuid(), nullable=False),
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        sa.Column("company_permission_id", sa.Uuid(), nullable=False),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["company_id", "company_permission_id"],
+            ["company_permission.company_id", "company_permission.id"],
+            name="fk_company_role_permission_company_permission",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["company_id", "role_id"],
+            ["company_role.company_id", "company_role.role_id"],
+            name="fk_company_role_permission_company_role",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "company_id",
+            "role_id",
+            "company_permission_id",
+        ),
+        sa.UniqueConstraint(
+            "company_id",
+            "role_id",
+            "company_permission_id",
+            name="uq_company_role_permission",
+        ),
+    )
+    op.create_index(
+        "ix_company_role_permission_company_permission",
+        "company_role_permission",
+        ["company_id", "company_permission_id"],
+        unique=False,
+    )
+    op.create_table(
+        "user_role",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["role.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+        sa.UniqueConstraint("user_id", "role_id", name="uq_user_role"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_role")
+    op.drop_index(
+        "ix_company_role_permission_company_permission",
+        table_name="company_role_permission",
+    )
+    op.drop_table("company_role_permission")
+    op.drop_table("role_global_permission")
+    op.drop_table("company_permission")
+    op.drop_table("global_permission")

--- a/alembic/versions/c9f4a6b8d210_seed_default_api_permissions.py
+++ b/alembic/versions/c9f4a6b8d210_seed_default_api_permissions.py
@@ -1,0 +1,214 @@
+"""Seed protected default API permissions.
+
+Revision ID: c9f4a6b8d210
+Revises: b7c2d4e6f809
+Create Date: 2026-08-07 16:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Sequence, Union
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c9f4a6b8d210"
+down_revision: Union[str, None] = "b7c2d4e6f809"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SYSTEM_PERMISSION_NAMESPACE = uuid5(
+    NAMESPACE_URL,
+    "https://userverse.softwareverse.co.za/system-permissions",
+)
+
+PERMISSIONS = (
+    ("company.read", "Read company details.", ("Owner", "Administrator", "Viewer")),
+    ("company.update", "Update company details.", ("Owner", "Administrator")),
+    ("company.delete", "Delete a company.", ("Owner",)),
+    (
+        "company.members.read",
+        "Read company members.",
+        ("Owner", "Administrator", "Viewer"),
+    ),
+    (
+        "company.members.add",
+        "Add members to a company.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.members.role.update",
+        "Update a company member's role.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.members.remove",
+        "Remove members from a company.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.roles.read",
+        "Read roles enabled for a company.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.roles.assign",
+        "Enable a global role for a company.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.roles.unassign",
+        "Disable a global role for a company.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.read",
+        "Read company permissions and effective role permissions.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.create",
+        "Create company permissions.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.update",
+        "Update company permissions.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.delete",
+        "Delete company permissions.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.assign",
+        "Assign company permissions to company roles.",
+        ("Owner", "Administrator"),
+    ),
+    (
+        "company.permissions.unassign",
+        "Remove company permissions from company roles.",
+        ("Owner", "Administrator"),
+    ),
+)
+
+
+def _permission_id(name: str) -> UUID:
+    return uuid5(SYSTEM_PERMISSION_NAMESPACE, name)
+
+
+def _tables():
+    global_permission = sa.table(
+        "global_permission",
+        sa.column("id", sa.Uuid()),
+        sa.column("name", sa.String()),
+        sa.column("description", sa.String()),
+        sa.column("_created_at", sa.DateTime(timezone=True)),
+        sa.column("_updated_at", sa.DateTime(timezone=True)),
+        sa.column("_closed_at", sa.DateTime(timezone=True)),
+        sa.column("primary_meta_data", sa.JSON()),
+        sa.column("secondary_meta_data", sa.JSON()),
+    )
+    role = sa.table(
+        "role",
+        sa.column("id", sa.Uuid()),
+        sa.column("name", sa.String()),
+        sa.column("_closed_at", sa.DateTime(timezone=True)),
+    )
+    role_global_permission = sa.table(
+        "role_global_permission",
+        sa.column("role_id", sa.Uuid()),
+        sa.column("global_permission_id", sa.Uuid()),
+        sa.column("_created_at", sa.DateTime(timezone=True)),
+        sa.column("_updated_at", sa.DateTime(timezone=True)),
+        sa.column("_closed_at", sa.DateTime(timezone=True)),
+        sa.column("primary_meta_data", sa.JSON()),
+        sa.column("secondary_meta_data", sa.JSON()),
+    )
+    return global_permission, role, role_global_permission
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    global_permission, role, role_global_permission = _tables()
+    now = datetime.now(timezone.utc)
+
+    for name, description, default_roles in PERMISSIONS:
+        permission_id = _permission_id(name)
+        record_by_name = connection.execute(
+            sa.select(global_permission.c.id).where(global_permission.c.name == name)
+        ).scalar_one_or_none()
+        record_by_id = connection.execute(
+            sa.select(global_permission.c.name).where(
+                global_permission.c.id == permission_id
+            )
+        ).scalar_one_or_none()
+        if (
+            record_by_name is not None and UUID(str(record_by_name)) != permission_id
+        ) or (record_by_id is not None and record_by_id != name):
+            raise RuntimeError(
+                f"Reserved system permission conflict for '{name}' ({permission_id})."
+            )
+        if record_by_name is None:
+            connection.execute(
+                global_permission.insert().values(
+                    id=permission_id,
+                    name=name,
+                    description=description,
+                    _created_at=now,
+                    _updated_at=now,
+                    _closed_at=None,
+                    primary_meta_data={
+                        "system": True,
+                        "kind": "default_api_permission",
+                    },
+                    secondary_meta_data={},
+                )
+            )
+
+        role_rows = connection.execute(
+            sa.select(role.c.id, role.c.name).where(
+                role.c.name.in_(default_roles),
+                role.c._closed_at.is_(None),
+            )
+        ).all()
+        for role_id, role_name in role_rows:
+            link_exists = connection.execute(
+                sa.select(role_global_permission.c.role_id).where(
+                    role_global_permission.c.role_id == role_id,
+                    role_global_permission.c.global_permission_id == permission_id,
+                )
+            ).first()
+            if link_exists is None:
+                connection.execute(
+                    role_global_permission.insert().values(
+                        role_id=role_id,
+                        global_permission_id=permission_id,
+                        _created_at=now,
+                        _updated_at=now,
+                        _closed_at=None,
+                        primary_meta_data={
+                            "system_default": True,
+                            "role": role_name,
+                        },
+                        secondary_meta_data={},
+                    )
+                )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    global_permission, _, role_global_permission = _tables()
+    permission_ids = [_permission_id(name) for name, _, _ in PERMISSIONS]
+    connection.execute(
+        role_global_permission.delete().where(
+            role_global_permission.c.global_permission_id.in_(permission_ids)
+        )
+    )
+    connection.execute(
+        global_permission.delete().where(global_permission.c.id.in_(permission_ids))
+    )

--- a/alembic/versions/d1e5f7a9b302_add_superuser_bootstrap_control.py
+++ b/alembic/versions/d1e5f7a9b302_add_superuser_bootstrap_control.py
@@ -1,0 +1,106 @@
+"""Add offline superuser bootstrap control and privileged audit events.
+
+Revision ID: d1e5f7a9b302
+Revises: c9f4a6b8d210
+Create Date: 2026-08-07 18:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "d1e5f7a9b302"
+down_revision: Union[str, None] = "c9f4a6b8d210"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _audit_columns() -> list[sa.Column]:
+    return [
+        sa.Column(
+            "_created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("_closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("primary_meta_data", sa.JSON(), nullable=False),
+        sa.Column("secondary_meta_data", sa.JSON(), nullable=False),
+    ]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "superuser_bootstrap_control",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("bootstrap_user_id", sa.Uuid(), nullable=True),
+        sa.Column("bootstrap_completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("bootstrap_method", sa.String(length=64), nullable=True),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["bootstrap_user_id"],
+            ["user.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("id = 1", name="ck_superuser_bootstrap_singleton"),
+    )
+    op.create_table(
+        "privileged_access_event",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("actor_user_id", sa.Uuid(), nullable=True),
+        sa.Column("target_user_id", sa.Uuid(), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column("reason", sa.String(length=1024), nullable=False),
+        sa.Column("previous_superuser", sa.Boolean(), nullable=False),
+        sa.Column("resulting_superuser", sa.Boolean(), nullable=False),
+        sa.Column("request_id", sa.String(length=128), nullable=True),
+        *_audit_columns(),
+        sa.ForeignKeyConstraint(
+            ["actor_user_id"],
+            ["user.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_user_id"],
+            ["user.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_privileged_access_event_target_created",
+        "privileged_access_event",
+        ["target_user_id", "_created_at"],
+        unique=False,
+    )
+    op.bulk_insert(
+        sa.table(
+            "superuser_bootstrap_control",
+            sa.column("id", sa.Integer()),
+            sa.column("primary_meta_data", sa.JSON()),
+            sa.column("secondary_meta_data", sa.JSON()),
+        ),
+        [
+            {
+                "id": 1,
+                "primary_meta_data": {},
+                "secondary_meta_data": {},
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_privileged_access_event_target_created",
+        table_name="privileged_access_event",
+    )
+    op.drop_table("privileged_access_event")
+    op.drop_table("superuser_bootstrap_control")

--- a/app/api/routers/company/permissions.py
+++ b/app/api/routers/company/permissions.py
@@ -1,0 +1,169 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from app.api.dependencies.common import CommonJWTRouteDependencies
+from app.models.company.roles import RoleReadModel
+from app.models.generic_pagination import PaginatedResponse
+from app.models.generic_response import GenericResponseModel
+from app.models.permission_response_messages import PermissionResponseMessages
+from app.models.permissions import (
+    PermissionCreateModel,
+    PermissionQueryParamsModel,
+    PermissionReadModel,
+    PermissionUpdateModel,
+)
+from app.services.permission import PermissionService
+from app.utils.shared_context import SharedContext
+
+router = APIRouter(tags=["Company Permission Management"])
+
+
+def _service(common: CommonJWTRouteDependencies) -> PermissionService:
+    return PermissionService(SharedContext(user=common.user, db_session=common.session))
+
+
+@router.post(
+    "/company/{company_id}/permissions",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GenericResponseModel[PermissionReadModel],
+)
+def create_company_permission_api(
+    company_id: UUID,
+    payload: PermissionCreateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).create_company_permission(company_id, payload)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.CREATED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/company/{company_id}/permissions",
+    response_model=GenericResponseModel[PaginatedResponse[PermissionReadModel]],
+)
+def get_company_permissions_api(
+    company_id: UUID,
+    query_params: PermissionQueryParamsModel = Depends(),
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).get_company_permissions(company_id, query_params)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.FOUND.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.patch(
+    "/company/{company_id}/permissions/{permission_id}",
+    response_model=GenericResponseModel[PermissionReadModel],
+)
+def update_company_permission_api(
+    company_id: UUID,
+    permission_id: UUID,
+    payload: PermissionUpdateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).update_company_permission(
+        company_id,
+        permission_id,
+        payload,
+    )
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.UPDATED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/company/{company_id}/permissions/{permission_id}",
+    response_model=GenericResponseModel[dict],
+)
+def delete_company_permission_api(
+    company_id: UUID,
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).delete_company_permission(company_id, permission_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.DELETED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/company/{company_id}/roles/{role_id}/permissions",
+    response_model=GenericResponseModel[list[PermissionReadModel]],
+)
+def get_company_role_permissions_api(
+    company_id: UUID,
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).get_company_role_permissions(company_id, role_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.FOUND.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.post(
+    "/company/{company_id}/roles/{role_id}/permissions/{permission_id}",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GenericResponseModel[RoleReadModel],
+)
+def assign_company_permission_api(
+    company_id: UUID,
+    role_id: UUID,
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).assign_company_permission(
+        company_id,
+        role_id,
+        permission_id,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.ASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/company/{company_id}/roles/{role_id}/permissions/{permission_id}",
+    response_model=GenericResponseModel[RoleReadModel],
+)
+def remove_company_permission_api(
+    company_id: UUID,
+    role_id: UUID,
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).remove_company_permission(
+        company_id,
+        role_id,
+        permission_id,
+    )
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.UNASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )

--- a/app/api/routers/permissions.py
+++ b/app/api/routers/permissions.py
@@ -1,0 +1,155 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from app.api.dependencies.common import CommonJWTRouteDependencies
+from app.models.app_error import AppErrorResponseModel
+from app.models.company.roles import RoleReadModel
+from app.models.generic_pagination import PaginatedResponse
+from app.models.generic_response import GenericResponseModel
+from app.models.permission_response_messages import PermissionResponseMessages
+from app.models.permissions import (
+    PermissionCreateModel,
+    PermissionQueryParamsModel,
+    PermissionReadModel,
+    PermissionUpdateModel,
+)
+from app.services.permission import PermissionService
+from app.utils.shared_context import SharedContext
+
+router = APIRouter(tags=["Global Permission Management"])
+
+
+def _service(common: CommonJWTRouteDependencies) -> PermissionService:
+    return PermissionService(SharedContext(user=common.user, db_session=common.session))
+
+
+@router.post(
+    "/permissions",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GenericResponseModel[PermissionReadModel],
+    responses={
+        403: {"model": AppErrorResponseModel},
+        409: {"model": AppErrorResponseModel},
+    },
+)
+def create_global_permission_api(
+    payload: PermissionCreateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).create_global_permission(payload)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.CREATED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/permissions",
+    response_model=GenericResponseModel[PaginatedResponse[PermissionReadModel]],
+)
+def get_global_permissions_api(
+    query_params: PermissionQueryParamsModel = Depends(),
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).get_global_permissions(query_params)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.FOUND.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.patch(
+    "/permissions/{permission_id}",
+    response_model=GenericResponseModel[PermissionReadModel],
+)
+def update_global_permission_api(
+    permission_id: UUID,
+    payload: PermissionUpdateModel,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).update_global_permission(permission_id, payload)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.UPDATED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/permissions/{permission_id}",
+    response_model=GenericResponseModel[dict],
+)
+def delete_global_permission_api(
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).delete_global_permission(permission_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.DELETED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/roles/{role_id}/permissions",
+    response_model=GenericResponseModel[list[PermissionReadModel]],
+)
+def get_global_role_permissions_api(
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).get_global_role_permissions(role_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.FOUND.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.post(
+    "/roles/{role_id}/permissions/{permission_id}",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GenericResponseModel[RoleReadModel],
+)
+def assign_global_permission_api(
+    role_id: UUID,
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).assign_global_permission(role_id, permission_id)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.ASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/roles/{role_id}/permissions/{permission_id}",
+    response_model=GenericResponseModel[RoleReadModel],
+)
+def remove_global_permission_api(
+    role_id: UUID,
+    permission_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).remove_global_permission(role_id, permission_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.UNASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )

--- a/app/api/routers/platform_roles.py
+++ b/app/api/routers/platform_roles.py
@@ -1,0 +1,72 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
+
+from app.api.dependencies.common import CommonJWTRouteDependencies
+from app.models.company.roles import RoleReadModel
+from app.models.generic_response import GenericResponseModel
+from app.models.permission_response_messages import PlatformRoleResponseMessages
+from app.services.permission import PermissionService
+from app.utils.shared_context import SharedContext
+
+router = APIRouter(tags=["Platform Role Management"])
+
+
+def _service(common: CommonJWTRouteDependencies) -> PermissionService:
+    return PermissionService(SharedContext(user=common.user, db_session=common.session))
+
+
+@router.get(
+    "/users/{user_id}/roles",
+    response_model=GenericResponseModel[list[RoleReadModel]],
+)
+def get_platform_roles_api(
+    user_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).get_platform_roles(user_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PlatformRoleResponseMessages.FOUND.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.post(
+    "/users/{user_id}/roles/{role_id}",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GenericResponseModel[list[RoleReadModel]],
+)
+def assign_platform_role_api(
+    user_id: UUID,
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).assign_platform_role(user_id, role_id)
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content=GenericResponseModel(
+            message=PlatformRoleResponseMessages.ASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )
+
+
+@router.delete(
+    "/users/{user_id}/roles/{role_id}",
+    response_model=GenericResponseModel[list[RoleReadModel]],
+)
+def remove_platform_role_api(
+    user_id: UUID,
+    role_id: UUID,
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    response = _service(common).remove_platform_role(user_id, role_id)
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PlatformRoleResponseMessages.UNASSIGNED.value,
+            data=response,
+        ).model_dump(mode="json"),
+    )

--- a/app/api/routers/user/user_profile_routes.py
+++ b/app/api/routers/user/user_profile_routes.py
@@ -14,9 +14,12 @@ from app.models.company.response_messages import CompanyUserResponseMessages
 from app.models.generic_response import GenericResponseModel
 from app.models.generic_pagination import PaginatedResponse
 from app.models.app_error import AppErrorResponseModel
+from app.models.permission_response_messages import PermissionResponseMessages
+from app.models.permissions import PermissionReadModel
 
 # Logic
 from app.services.user.profile import UserProfileService
+from app.services.permission import PermissionService
 
 router = APIRouter(
     prefix="/user",
@@ -113,6 +116,30 @@ def get_user_companies_api(
         content=GenericResponseModel(
             message=CompanyUserResponseMessages.GET_COMPANY_USERS.value,
             data=response.model_dump(mode="json"),
+        ).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/permissions",
+    status_code=status.HTTP_200_OK,
+    response_model=GenericResponseModel[list[PermissionReadModel]],
+)
+def get_my_platform_permissions_api(
+    common: CommonJWTRouteDependencies = Depends(),
+):
+    service = PermissionService(
+        SharedContext(
+            user=common.user,
+            db_session=common.session,
+            enforce_status_check=True,
+        )
+    )
+    response = service.get_my_platform_permissions()
+    return JSONResponse(
+        content=GenericResponseModel(
+            message=PermissionResponseMessages.FOUND.value,
+            data=response,
         ).model_dump(mode="json"),
     )
 

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Trusted operator commands for Userverse."""

--- a/app/cli/admin.py
+++ b/app/cli/admin.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import click
+
+from app.repository.database.session_manager import DatabaseSessionManager
+from app.services.superuser_bootstrap import (
+    SuperuserBootstrapCandidate,
+    SuperuserBootstrapError,
+    SuperuserBootstrapResult,
+    SuperuserBootstrapService,
+)
+
+
+def _candidate(
+    manager: DatabaseSessionManager, email: str
+) -> SuperuserBootstrapCandidate:
+    session = manager.session_object()
+    try:
+        return SuperuserBootstrapService(session).get_candidate(email)
+    finally:
+        session.close()
+
+
+def _bootstrap(
+    manager: DatabaseSessionManager,
+    *,
+    email: str,
+    reason: str,
+    user_id: UUID,
+) -> SuperuserBootstrapResult:
+    session = manager.session_object()
+    try:
+        return SuperuserBootstrapService(session).bootstrap(
+            email=email,
+            reason=reason,
+            expected_user_id=user_id,
+        )
+    finally:
+        session.close()
+
+
+@click.group()
+def cli() -> None:
+    """Run trusted Userverse administration commands."""
+
+
+@cli.command("bootstrap-superuser")
+@click.option(
+    "--email",
+    required=True,
+    help="Email of an existing active and verified user.",
+)
+@click.option(
+    "--reason",
+    required=True,
+    help="Operational reason recorded in the privileged audit event.",
+)
+@click.option(
+    "--confirm-user-id",
+    type=click.UUID,
+    help="Exact target UUID required for non-interactive execution.",
+)
+def bootstrap_superuser(
+    email: str,
+    reason: str,
+    confirm_user_id: UUID | None,
+) -> None:
+    """Promote the one and only initial superuser."""
+    manager = DatabaseSessionManager()
+    try:
+        try:
+            candidate = _candidate(manager, email)
+        except SuperuserBootstrapError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        if confirm_user_id is not None:
+            if confirm_user_id != candidate.user_id:
+                raise click.ClickException(
+                    "--confirm-user-id does not match the resolved user."
+                )
+        else:
+            click.confirm(
+                (
+                    "Promote the existing active user "
+                    f"{candidate.email} ({candidate.user_id}) to initial superuser?"
+                ),
+                abort=True,
+            )
+
+        try:
+            result = _bootstrap(
+                manager,
+                email=email,
+                reason=reason,
+                user_id=candidate.user_id,
+            )
+        except SuperuserBootstrapError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        if result.changed:
+            click.echo(
+                f"Initial superuser bootstrap completed for user ID {result.user_id}."
+            )
+        else:
+            click.echo(
+                f"Initial superuser bootstrap was already complete for user ID "
+                f"{result.user_id}."
+            )
+    finally:
+        manager.engine.dispose()
+
+
+def main() -> None:
+    cli()

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,9 @@ from app.api.routers.company import (
     roles,
 )
 from app.api.routers import roles as global_roles
+from app.api.routers import permissions as global_permissions
+from app.api.routers import platform_roles
+from app.api.routers.company import permissions as company_permissions
 
 # utils
 from app.configs import settings
@@ -90,7 +93,10 @@ def create_app() -> FastAPI:
     app.include_router(company.router)
     app.include_router(users.router)
     app.include_router(roles.router)
+    app.include_router(company_permissions.router)
     app.include_router(global_roles.router)
+    app.include_router(global_permissions.router)
+    app.include_router(platform_roles.router)
 
     # Root route
     @app.get("/", tags=["Root"])

--- a/app/models/company/roles.py
+++ b/app/models/company/roles.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from pydantic import field_validator, Field
 
 from app.models.generic_pagination import PaginationParams
+from app.models.permissions import PermissionReadModel
 
 
 class CompanyDefaultRoles(str, Enum):
@@ -48,7 +49,7 @@ class RoleReadModel(BaseModel):
     id: str | None = None
     name: Optional[str] = None
     description: Optional[str] = None
-    permissions: list[str] = Field(default_factory=list)
+    permissions: list[PermissionReadModel] = Field(default_factory=list)
 
 
 class RoleAssignCompaniesModel(BaseModel):

--- a/app/models/permission_response_messages.py
+++ b/app/models/permission_response_messages.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class PermissionResponseMessages(str, Enum):
+    CREATED = "Permission has been created successfully."
+    FOUND = "Permissions retrieved successfully."
+    UPDATED = "Permission has been updated successfully."
+    DELETED = "Permission has been deleted successfully."
+    ASSIGNED = "Permission has been assigned successfully."
+    UNASSIGNED = "Permission has been unassigned successfully."
+    NOT_FOUND = "No permission found with the given identifier."
+    ALREADY_EXISTS = "A permission with the same name already exists."
+    ALREADY_ASSIGNED = "Permission is already assigned to the role."
+    ASSIGNMENT_NOT_FOUND = "Permission is not assigned to the role."
+    MANAGEMENT_FORBIDDEN = "Access denied. You cannot manage these permissions."
+
+
+class PlatformRoleResponseMessages(str, Enum):
+    FOUND = "Platform roles retrieved successfully."
+    ASSIGNED = "Platform role has been assigned successfully."
+    UNASSIGNED = "Platform role has been unassigned successfully."
+    ALREADY_ASSIGNED = "Platform role is already assigned to the user."
+    ASSIGNMENT_NOT_FOUND = "Platform role is not assigned to the user."

--- a/app/models/permission_response_messages.py
+++ b/app/models/permission_response_messages.py
@@ -13,6 +13,12 @@ class PermissionResponseMessages(str, Enum):
     ALREADY_ASSIGNED = "Permission is already assigned to the role."
     ASSIGNMENT_NOT_FOUND = "Permission is not assigned to the role."
     MANAGEMENT_FORBIDDEN = "Access denied. You cannot manage these permissions."
+    SYSTEM_PERMISSION_PROTECTED = (
+        "System permission identities cannot be renamed or deleted."
+    )
+    SYSTEM_PERMISSION_CONFLICT = (
+        "A reserved system permission name or identifier is already in use."
+    )
 
 
 class PlatformRoleResponseMessages(str, Enum):

--- a/app/models/permissions.py
+++ b/app/models/permissions.py
@@ -1,0 +1,64 @@
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.models.generic_pagination import PaginationParams
+
+
+class PermissionScope(str, Enum):
+    GLOBAL = "global"
+    COMPANY = "company"
+
+
+class PermissionCreateModel(BaseModel):
+    name: str = Field(..., min_length=1, max_length=256)
+    description: Optional[str] = Field(default=None, max_length=256)
+
+    @field_validator("name")
+    @classmethod
+    def trim_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Permission name cannot be blank.")
+        return value
+
+
+class PermissionUpdateModel(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=256)
+    description: Optional[str] = Field(default=None, max_length=256)
+
+    @field_validator("name")
+    @classmethod
+    def trim_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError("Permission name cannot be blank.")
+        return value
+
+    @model_validator(mode="after")
+    def require_update(self):
+        if not self.model_fields_set.intersection({"name", "description"}):
+            raise ValueError("At least one permission field must be provided.")
+        if "name" in self.model_fields_set and self.name is None:
+            raise ValueError("Permission name cannot be null.")
+        return self
+
+
+class PermissionReadModel(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    scope: PermissionScope
+    company_id: Optional[UUID] = None
+
+
+class PermissionQueryParamsModel(PaginationParams):
+    name: Optional[str] = Field(None, description="Filter by permission name")
+    description: Optional[str] = Field(
+        None,
+        description="Filter by permission description",
+    )

--- a/app/models/system_permissions.py
+++ b/app/models/system_permissions.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass
+from enum import Enum
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+SYSTEM_PERMISSION_NAMESPACE = uuid5(
+    NAMESPACE_URL,
+    "https://userverse.softwareverse.co.za/system-permissions",
+)
+
+
+class SystemPermission(str, Enum):
+    COMPANY_READ = "company.read"
+    COMPANY_UPDATE = "company.update"
+    COMPANY_DELETE = "company.delete"
+    COMPANY_MEMBERS_READ = "company.members.read"
+    COMPANY_MEMBERS_ADD = "company.members.add"
+    COMPANY_MEMBERS_ROLE_UPDATE = "company.members.role.update"
+    COMPANY_MEMBERS_REMOVE = "company.members.remove"
+    COMPANY_ROLES_READ = "company.roles.read"
+    COMPANY_ROLES_ASSIGN = "company.roles.assign"
+    COMPANY_ROLES_UNASSIGN = "company.roles.unassign"
+    COMPANY_PERMISSIONS_READ = "company.permissions.read"
+    COMPANY_PERMISSIONS_CREATE = "company.permissions.create"
+    COMPANY_PERMISSIONS_UPDATE = "company.permissions.update"
+    COMPANY_PERMISSIONS_DELETE = "company.permissions.delete"
+    COMPANY_PERMISSIONS_ASSIGN = "company.permissions.assign"
+    COMPANY_PERMISSIONS_UNASSIGN = "company.permissions.unassign"
+
+    @property
+    def permission_id(self) -> UUID:
+        return uuid5(SYSTEM_PERMISSION_NAMESPACE, self.value)
+
+
+@dataclass(frozen=True)
+class SystemPermissionDefinition:
+    permission: SystemPermission
+    description: str
+    default_roles: frozenset[str]
+
+    @property
+    def id(self) -> UUID:
+        return self.permission.permission_id
+
+    @property
+    def name(self) -> str:
+        return self.permission.value
+
+
+OWNER = "Owner"
+ADMINISTRATOR = "Administrator"
+VIEWER = "Viewer"
+OWNER_AND_ADMINISTRATOR = frozenset({OWNER, ADMINISTRATOR})
+ALL_DEFAULT_ROLES = frozenset({OWNER, ADMINISTRATOR, VIEWER})
+
+SYSTEM_PERMISSION_DEFINITIONS = (
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_READ,
+        "Read company details.",
+        ALL_DEFAULT_ROLES,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_UPDATE,
+        "Update company details.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_DELETE,
+        "Delete a company.",
+        frozenset({OWNER}),
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_MEMBERS_READ,
+        "Read company members.",
+        ALL_DEFAULT_ROLES,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_MEMBERS_ADD,
+        "Add members to a company.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_MEMBERS_ROLE_UPDATE,
+        "Update a company member's role.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_MEMBERS_REMOVE,
+        "Remove members from a company.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_ROLES_READ,
+        "Read roles enabled for a company.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_ROLES_ASSIGN,
+        "Enable a global role for a company.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_ROLES_UNASSIGN,
+        "Disable a global role for a company.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_READ,
+        "Read company permissions and effective role permissions.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_CREATE,
+        "Create company permissions.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_UPDATE,
+        "Update company permissions.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_DELETE,
+        "Delete company permissions.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_ASSIGN,
+        "Assign company permissions to company roles.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+    SystemPermissionDefinition(
+        SystemPermission.COMPANY_PERMISSIONS_UNASSIGN,
+        "Remove company permissions from company roles.",
+        OWNER_AND_ADMINISTRATOR,
+    ),
+)
+
+SYSTEM_PERMISSION_BY_ID = {
+    definition.id: definition for definition in SYSTEM_PERMISSION_DEFINITIONS
+}
+SYSTEM_PERMISSION_BY_NAME = {
+    definition.name: definition for definition in SYSTEM_PERMISSION_DEFINITIONS
+}
+
+
+def is_system_permission_id(permission_id: UUID) -> bool:
+    return permission_id in SYSTEM_PERMISSION_BY_ID

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -60,6 +60,7 @@ class CompanyRepository(BaseSQLRepository[Company]):
 
     def _ensure_default_roles(self) -> dict[str, Role]:
         default_roles: dict[str, Role] = {}
+        created_role_names: set[str] = set()
         for default_role in CompanyDefaultRoles:
             role = (
                 self.db_session.query(Role)
@@ -76,9 +77,16 @@ class CompanyRepository(BaseSQLRepository[Company]):
                 )
                 self.db_session.add(role)
                 self.db_session.flush()
+                created_role_names.add(default_role.name_value)
             elif role.description != default_role.description:
                 role.description = default_role.description
             default_roles[default_role.name_value] = role
+        from app.repository.permission import SystemPermissionRepository
+
+        SystemPermissionRepository(self.db_session).seed_new_default_roles(
+            default_roles,
+            created_role_names,
+        )
         self.db_session.commit()
         return default_roles
 

--- a/app/repository/company.py
+++ b/app/repository/company.py
@@ -216,6 +216,13 @@ class CompanyRepository(BaseSQLRepository[Company]):
                 Company.id.asc(),
             ],
         ).all()
+        from app.repository.permission import RolePermissionRepository
+
+        permission_map = RolePermissionRepository(
+            self.db_session
+        ).effective_permissions_by_assignments(
+            [(assoc.company_id, assoc.role_id) for assoc in results]
+        )
         companies = [
             UserCompanyReadModel(
                 **self._to_read_model(assoc.company).model_dump(),
@@ -223,6 +230,10 @@ class CompanyRepository(BaseSQLRepository[Company]):
                     id=str(assoc.role.id),
                     name=assoc.role.name,
                     description=assoc.role.description,
+                    permissions=permission_map.get(
+                        (assoc.company_id, assoc.role_id),
+                        [],
+                    ),
                 ),
             )
             for assoc in results

--- a/app/repository/company_role.py
+++ b/app/repository/company_role.py
@@ -18,7 +18,15 @@ from app.models.company.roles import (
 )
 from app.models.user.user import UserReadModel
 from app.repository.base import BaseSQLRepository
-from app.repository.database.tables import AssociationUserCompany, CompanyRole, Role
+from app.repository.database.tables import (
+    AssociationUserCompany,
+    CompanyRole,
+    CompanyRolePermission,
+    Role,
+    RoleGlobalPermission,
+    User,
+    UserRole,
+)
 from app.utils.app_error import AppError
 
 
@@ -39,10 +47,28 @@ class RoleRepository(BaseSQLRepository[Role]):
         self.company_id = company_id
 
     @staticmethod
-    def _to_read_model(role: Role) -> RoleReadModel:
+    def _to_read_model(
+        role: Role,
+    ) -> RoleReadModel:
         data = BaseSQLRepository.serialize(role)
         data["id"] = str(role.id)
         return RoleReadModel(**data)
+
+    @staticmethod
+    def _to_scoped_read_model(
+        role: Role,
+        session: Session,
+        company_id: UUID | None = None,
+    ) -> RoleReadModel:
+        base_model = RoleRepository._to_read_model(role)
+        if isinstance(session, Session):
+            from app.repository.permission import RolePermissionRepository
+
+            permission_repository = RolePermissionRepository(session)
+            if company_id is not None:
+                return permission_repository.company_role_read(company_id, role)
+            return permission_repository.global_role_read(role)
+        return base_model
 
     def get_roles(self, payload: RoleQueryParamsModel) -> dict:
         try:
@@ -51,12 +77,22 @@ class RoleRepository(BaseSQLRepository[Role]):
                 query = query.filter(Role.name.ilike(f"%{payload.name}%"))
             if payload.description:
                 query = query.filter(Role.description.ilike(f"%{payload.description}%"))
-            return self.paginate(
+            result = self.paginate(
                 query,
                 page=payload.page,
                 limit=payload.limit,
                 order_by=[Role.name.asc()],
             )
+            from app.repository.permission import RolePermissionRepository
+
+            permission_map = RolePermissionRepository(
+                self.db_session
+            ).global_permissions_by_role_ids(
+                {record["id"] for record in result["records"]}
+            )
+            for record in result["records"]:
+                record["permissions"] = permission_map.get(record["id"], [])
+            return result
         except Exception as exc:
             raise AppError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -126,7 +162,7 @@ class RoleRepository(BaseSQLRepository[Role]):
                 key="created_by",
                 value=created_by.model_dump(mode="json"),
             )
-            return self._to_read_model(role)
+            return self._to_scoped_read_model(role, self.db_session)
         except IntegrityError as exc:
             self.db_session.rollback()
             raise AppError(
@@ -162,7 +198,7 @@ class RoleRepository(BaseSQLRepository[Role]):
                 role.description = payload.description
             self.db_session.commit()
             self.db_session.refresh(role)
-            return self._to_read_model(role)
+            return self._to_scoped_read_model(role, self.db_session)
         except Exception as exc:
             self.db_session.rollback()
             raise AppError(
@@ -223,6 +259,29 @@ class RoleRepository(BaseSQLRepository[Role]):
                 raise ValueError(
                     "Cannot delete a role that is still assigned to active company users."
                 )
+            if isinstance(self.db_session, Session) and (
+                self.db_session.query(UserRole)
+                .join(User, User.id == UserRole.user_id)
+                .filter(
+                    UserRole.role_id == role_id,
+                    UserRole._closed_at.is_(None),
+                    User._closed_at.is_(None),
+                )
+                .count()
+            ):
+                raise ValueError(
+                    "Cannot delete a role that is still assigned to active platform users."
+                )
+
+            self.db_session.query(RoleGlobalPermission).filter(
+                RoleGlobalPermission.role_id == role_id
+            ).delete(synchronize_session=False)
+            self.db_session.query(CompanyRolePermission).filter(
+                CompanyRolePermission.role_id == role_id
+            ).delete(synchronize_session=False)
+            self.db_session.query(UserRole).filter(UserRole.role_id == role_id).delete(
+                synchronize_session=False
+            )
 
             role._closed_at = self._now_sql()
             self.db_session.add(role)
@@ -265,17 +324,24 @@ class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
                 query = query.filter(Role.name.ilike(f"%{payload.name}%"))
             if payload.description:
                 query = query.filter(Role.description.ilike(f"%{payload.description}%"))
-            return self.paginate(
+            result = self.paginate(
                 query,
                 page=payload.page,
                 limit=payload.limit,
                 order_by=[Role.name.asc()],
             )
-            records = []
-            for role in result["records"]:
-                role["id"] = str(role["id"])
-                records.append(role)
-            result["records"] = records
+            from app.repository.permission import RolePermissionRepository
+
+            permission_map = RolePermissionRepository(
+                self.db_session
+            ).effective_permissions_by_assignments(
+                [(self.company_id, record["id"]) for record in result["records"]]
+            )
+            for record in result["records"]:
+                record["permissions"] = permission_map.get(
+                    (self.company_id, record["id"]),
+                    [],
+                )
             return result
         except Exception as exc:
             raise AppError(
@@ -351,7 +417,11 @@ class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
                 role.description = payload.description
             self.db_session.commit()
             self.db_session.refresh(role)
-            return RoleRepository._to_read_model(role)
+            return RoleRepository._to_scoped_read_model(
+                role,
+                self.db_session,
+                self.company_id,
+            )
         except Exception as exc:
             self.db_session.rollback()
             raise AppError(
@@ -376,7 +446,11 @@ class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
             key="assigned_by",
             value=assigned_by.model_dump(mode="json"),
         )
-        return RoleRepository._to_read_model(role)
+        return RoleRepository._to_scoped_read_model(
+            role,
+            self.db_session,
+            self.company_id,
+        )
 
     def assign_role_to_companies(
         self,
@@ -423,6 +497,10 @@ class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
                 error="Cannot unassign a role that is still assigned to active company users.",
             )
         assignment._closed_at = self._now_sql()
+        self.db_session.query(CompanyRolePermission).filter(
+            CompanyRolePermission.company_id == self.company_id,
+            CompanyRolePermission.role_id == role_id,
+        ).delete(synchronize_session=False)
         self.db_session.add(assignment)
         self.db_session.commit()
         return {"message": "Role unassigned successfully."}
@@ -474,6 +552,10 @@ class CompanyRoleAssignmentRepository(BaseSQLRepository[CompanyRole]):
                 error=f"Role '{payload.role_name_to_delete}' not found.",
             )
         assignment._closed_at = self._now_sql()
+        self.db_session.query(CompanyRolePermission).filter(
+            CompanyRolePermission.company_id == self.company_id,
+            CompanyRolePermission.role_id == role_to_delete.id,
+        ).delete(synchronize_session=False)
         self.db_session.add(assignment)
         self.db_session.commit()
         self.update_json_field(

--- a/app/repository/company_user.py
+++ b/app/repository/company_user.py
@@ -9,6 +9,7 @@ from app.models.company.response_messages import (
     CompanyUserResponseMessages,
 )
 from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
+from app.models.permissions import PermissionReadModel
 from app.models.company.user import CompanyUserAddModel, CompanyUserReadModel
 from app.models.generic_pagination import (
     PaginatedResponse,
@@ -29,7 +30,11 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         super().__init__(session)
 
     @staticmethod
-    def _to_company_user(user: User, role: Role) -> CompanyUserReadModel:
+    def _to_company_user(
+        user: User,
+        role: Role,
+        permissions: list[PermissionReadModel] | None = None,
+    ) -> CompanyUserReadModel:
         metadata = user.primary_meta_data or {}
         return CompanyUserReadModel(
             id=user.id,
@@ -43,6 +48,7 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
                 id=str(role.id),
                 name=role.name,
                 description=role.description,
+                permissions=permissions or [],
             ),
         )
 
@@ -109,7 +115,12 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             primary_meta_data={"added_by": added_by.model_dump(mode="json")},
             secondary_meta_data={"_legacy_role_name": role.name},
         )
-        return self._to_company_user(user, role)
+        from app.repository.permission import RolePermissionRepository
+
+        permissions = RolePermissionRepository(
+            self.db_session
+        ).get_company_role_permissions(company_id, role.id)
+        return self._to_company_user(user, role, permissions)
 
     def remove_user_from_company(
         self, company_id: UUID, user_id: UUID, removed_by
@@ -142,7 +153,12 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         self.db_session.refresh(assoc)
 
         user = self.db_session.query(User).filter(User.id == user_id).one()
-        return self._to_company_user(user, assoc.role)
+        from app.repository.permission import RolePermissionRepository
+
+        permissions = RolePermissionRepository(
+            self.db_session
+        ).get_company_role_permissions(company_id, assoc.role.id)
+        return self._to_company_user(user, assoc.role, permissions)
 
     def update_user_role(
         self, company_id: UUID, user_id: UUID, role_name: str, updated_by
@@ -173,7 +189,12 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
         self.db_session.refresh(assoc)
 
         user = self.db_session.query(User).filter(User.id == user_id).one()
-        return self._to_company_user(user, role)
+        from app.repository.permission import RolePermissionRepository
+
+        permissions = RolePermissionRepository(
+            self.db_session
+        ).get_company_role_permissions(company_id, role.id)
+        return self._to_company_user(user, role, permissions)
 
     def get_company_users(
         self, company_id: UUID, params: UserQueryParams
@@ -212,7 +233,21 @@ class CompanyUserRepository(BaseSQLRepository[AssociationUserCompany]):
             ],
         ).all()
 
-        users = [self._to_company_user(assoc.user, assoc.role) for assoc in results]
+        from app.repository.permission import RolePermissionRepository
+
+        permission_map = RolePermissionRepository(
+            self.db_session
+        ).effective_permissions_by_assignments(
+            [(company_id, assoc.role_id) for assoc in results]
+        )
+        users = [
+            self._to_company_user(
+                assoc.user,
+                assoc.role,
+                permission_map.get((company_id, assoc.role_id), []),
+            )
+            for assoc in results
+        ]
         return PaginatedResponse[CompanyUserReadModel](
             records=users,
             pagination=build_pagination_meta(

--- a/app/repository/database/session_manager.py
+++ b/app/repository/database/session_manager.py
@@ -16,16 +16,30 @@ class DatabaseSessionManager:
     expected_tables = (
         "association_user_company",
         "company",
+        "company_permission",
         "company_role",
+        "company_role_permission",
+        "global_permission",
         "role",
+        "role_global_permission",
         "user",
+        "user_role",
     )
     expected_columns = {
         "association_user_company": {"user_id", "company_id", "role_id"},
         "company": {"id", "email"},
+        "company_permission": {"id", "company_id", "name"},
         "company_role": {"company_id", "role_id"},
+        "company_role_permission": {
+            "company_id",
+            "role_id",
+            "company_permission_id",
+        },
+        "global_permission": {"id", "name"},
         "role": {"id", "name", "description"},
+        "role_global_permission": {"role_id", "global_permission_id"},
         "user": {"id", "email", "password"},
+        "user_role": {"user_id", "role_id"},
     }
     forbidden_columns = {
         "association_user_company": {"role_name", "user_level"},
@@ -91,9 +105,14 @@ class DatabaseSessionManager:
         from app.repository.database.tables import (  # noqa: F401
             AssociationUserCompany,
             Company,
+            CompanyPermission,
             CompanyRole,
+            CompanyRolePermission,
+            GlobalPermission,
             Role,
+            RoleGlobalPermission,
             User,
+            UserRole,
         )
 
     def _table_state(self) -> str:

--- a/app/repository/database/session_manager.py
+++ b/app/repository/database/session_manager.py
@@ -22,6 +22,8 @@ class DatabaseSessionManager:
         "global_permission",
         "role",
         "role_global_permission",
+        "privileged_access_event",
+        "superuser_bootstrap_control",
         "user",
         "user_role",
     )
@@ -38,6 +40,21 @@ class DatabaseSessionManager:
         "global_permission": {"id", "name"},
         "role": {"id", "name", "description"},
         "role_global_permission": {"role_id", "global_permission_id"},
+        "privileged_access_event": {
+            "id",
+            "target_user_id",
+            "action",
+            "source",
+            "reason",
+            "previous_superuser",
+            "resulting_superuser",
+        },
+        "superuser_bootstrap_control": {
+            "id",
+            "bootstrap_user_id",
+            "bootstrap_completed_at",
+            "bootstrap_method",
+        },
         "user": {"id", "email", "password"},
         "user_role": {"user_id", "role_id"},
     }
@@ -111,6 +128,8 @@ class DatabaseSessionManager:
             GlobalPermission,
             Role,
             RoleGlobalPermission,
+            PrivilegedAccessEvent,
+            SuperuserBootstrapControl,
             User,
             UserRole,
         )

--- a/app/repository/database/tables/__init__.py
+++ b/app/repository/database/tables/__init__.py
@@ -3,7 +3,27 @@ from app.repository.database.tables.association_user_company import (
 )
 from app.repository.database.tables.company import Company
 from app.repository.database.tables.company_role import CompanyRole
+from app.repository.database.tables.permission import (
+    CompanyPermission,
+    GlobalPermission,
+)
 from app.repository.database.tables.role import Role
+from app.repository.database.tables.role_permission import (
+    CompanyRolePermission,
+    RoleGlobalPermission,
+)
 from app.repository.database.tables.user import User
+from app.repository.database.tables.user_role import UserRole
 
-__all__ = ["AssociationUserCompany", "Company", "CompanyRole", "Role", "User"]
+__all__ = [
+    "AssociationUserCompany",
+    "Company",
+    "CompanyPermission",
+    "CompanyRole",
+    "CompanyRolePermission",
+    "GlobalPermission",
+    "Role",
+    "RoleGlobalPermission",
+    "User",
+    "UserRole",
+]

--- a/app/repository/database/tables/__init__.py
+++ b/app/repository/database/tables/__init__.py
@@ -14,6 +14,10 @@ from app.repository.database.tables.role_permission import (
 )
 from app.repository.database.tables.user import User
 from app.repository.database.tables.user_role import UserRole
+from app.repository.database.tables.superuser import (
+    PrivilegedAccessEvent,
+    SuperuserBootstrapControl,
+)
 
 __all__ = [
     "AssociationUserCompany",
@@ -24,6 +28,8 @@ __all__ = [
     "GlobalPermission",
     "Role",
     "RoleGlobalPermission",
+    "PrivilegedAccessEvent",
+    "SuperuserBootstrapControl",
     "User",
     "UserRole",
 ]

--- a/app/repository/database/tables/company.py
+++ b/app/repository/database/tables/company.py
@@ -31,6 +31,11 @@ class Company(BaseModel):
         cascade="all, delete-orphan",
         overlaps="role",
     )
+    permissions = relationship(
+        "CompanyPermission",
+        back_populates="company",
+        cascade="all, delete-orphan",
+    )
 
     @classmethod
     def get_company_by_email(cls, session, email: str) -> dict:

--- a/app/repository/database/tables/company_role.py
+++ b/app/repository/database/tables/company_role.py
@@ -26,3 +26,9 @@ class CompanyRole(BaseModel):
 
     company = relationship("Company", back_populates="roles", overlaps="role")
     role = relationship("Role", back_populates="companies", overlaps="company")
+    company_permission_links = relationship(
+        "CompanyRolePermission",
+        back_populates="company_role",
+        cascade="all, delete-orphan",
+        overlaps="permission,role_links",
+    )

--- a/app/repository/database/tables/permission.py
+++ b/app/repository/database/tables/permission.py
@@ -1,0 +1,53 @@
+from uuid import UUID, uuid4
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.repository.database.base_model import BaseModel
+
+
+class GlobalPermission(BaseModel):
+    __tablename__ = "global_permission"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    role_links = relationship(
+        "RoleGlobalPermission",
+        back_populates="permission",
+        cascade="all, delete-orphan",
+    )
+
+
+class CompanyPermission(BaseModel):
+    __tablename__ = "company_permission"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    company_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("company.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(256), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "company_id",
+            "name",
+            name="uq_company_permission_company_name",
+        ),
+        UniqueConstraint(
+            "company_id",
+            "id",
+            name="uq_company_permission_company_id_id",
+        ),
+    )
+
+    company = relationship("Company", back_populates="permissions")
+    role_links = relationship(
+        "CompanyRolePermission",
+        back_populates="permission",
+        cascade="all, delete-orphan",
+    )

--- a/app/repository/database/tables/role.py
+++ b/app/repository/database/tables/role.py
@@ -31,6 +31,16 @@ class Role(BaseModel):
         back_populates="role",
         overlaps="company,companies",
     )
+    global_permission_links = relationship(
+        "RoleGlobalPermission",
+        back_populates="role",
+        cascade="all, delete-orphan",
+    )
+    platform_user_links = relationship(
+        "UserRole",
+        back_populates="role",
+        cascade="all, delete-orphan",
+    )
 
     @staticmethod
     def to_dict(obj):

--- a/app/repository/database/tables/role_permission.py
+++ b/app/repository/database/tables/role_permission.py
@@ -1,0 +1,75 @@
+from uuid import UUID
+
+from sqlalchemy import (
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    UniqueConstraint,
+    Uuid,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.repository.database.base_model import BaseModel
+
+
+class RoleGlobalPermission(BaseModel):
+    __tablename__ = "role_global_permission"
+
+    role_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("role.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    global_permission_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("global_permission.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    role = relationship("Role", back_populates="global_permission_links")
+    permission = relationship("GlobalPermission", back_populates="role_links")
+
+
+class CompanyRolePermission(BaseModel):
+    __tablename__ = "company_role_permission"
+
+    company_id: Mapped[UUID] = mapped_column(Uuid, primary_key=True)
+    role_id: Mapped[UUID] = mapped_column(Uuid, primary_key=True)
+    company_permission_id: Mapped[UUID] = mapped_column(Uuid, primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["company_id", "role_id"],
+            ["company_role.company_id", "company_role.role_id"],
+            ondelete="CASCADE",
+            name="fk_company_role_permission_company_role",
+        ),
+        ForeignKeyConstraint(
+            ["company_id", "company_permission_id"],
+            ["company_permission.company_id", "company_permission.id"],
+            ondelete="CASCADE",
+            name="fk_company_role_permission_company_permission",
+        ),
+        UniqueConstraint(
+            "company_id",
+            "role_id",
+            "company_permission_id",
+            name="uq_company_role_permission",
+        ),
+        Index(
+            "ix_company_role_permission_company_permission",
+            "company_id",
+            "company_permission_id",
+        ),
+    )
+
+    company_role = relationship(
+        "CompanyRole",
+        back_populates="company_permission_links",
+        overlaps="permission,role_links",
+    )
+    permission = relationship(
+        "CompanyPermission",
+        back_populates="role_links",
+        overlaps="company_role,company_permission_links",
+    )

--- a/app/repository/database/tables/superuser.py
+++ b/app/repository/database/tables/superuser.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.repository.database.base_model import BaseModel
+
+
+class SuperuserBootstrapControl(BaseModel):
+    __tablename__ = "superuser_bootstrap_control"
+
+    SINGLETON_ID = 1
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    bootstrap_user_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("user.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    bootstrap_completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    bootstrap_method: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+    )
+
+
+class PrivilegedAccessEvent(BaseModel):
+    __tablename__ = "privileged_access_event"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    actor_user_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("user.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    target_user_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("user.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    action: Mapped[str] = mapped_column(String(64), nullable=False)
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    reason: Mapped[str] = mapped_column(String(1024), nullable=False)
+    previous_superuser: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    resulting_superuser: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    request_id: Mapped[str | None] = mapped_column(String(128), nullable=True)

--- a/app/repository/database/tables/user.py
+++ b/app/repository/database/tables/user.py
@@ -24,6 +24,11 @@ class User(BaseModel):
     is_superuser: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     companies = relationship("AssociationUserCompany", back_populates="user")
+    platform_role_links = relationship(
+        "UserRole",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     @classmethod
     def get_user_by_email(cls, session: Session, email: str) -> dict:

--- a/app/repository/database/tables/user_role.py
+++ b/app/repository/database/tables/user_role.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.repository.database.base_model import BaseModel
+
+
+class UserRole(BaseModel):
+    __tablename__ = "user_role"
+
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("user.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("role.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    __table_args__ = (UniqueConstraint("user_id", "role_id", name="uq_user_role"),)
+
+    user = relationship("User", back_populates="platform_role_links")
+    role = relationship("Role", back_populates="platform_user_links")

--- a/app/repository/permission.py
+++ b/app/repository/permission.py
@@ -1,0 +1,646 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+from fastapi import status
+from sqlalchemy import tuple_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.company.roles import RoleReadModel
+from app.models.generic_pagination import PaginatedResponse
+from app.models.permission_response_messages import (
+    PermissionResponseMessages,
+    PlatformRoleResponseMessages,
+)
+from app.models.permissions import (
+    PermissionCreateModel,
+    PermissionQueryParamsModel,
+    PermissionReadModel,
+    PermissionScope,
+    PermissionUpdateModel,
+)
+from app.models.user.account_status import UserAccountStatus
+from app.repository.base import BaseSQLRepository
+from app.repository.database.tables import (
+    Company,
+    CompanyPermission,
+    CompanyRole,
+    CompanyRolePermission,
+    GlobalPermission,
+    Role,
+    RoleGlobalPermission,
+    User,
+    UserRole,
+)
+from app.utils.app_error import AppError
+
+
+def _global_permission_model(permission: GlobalPermission) -> PermissionReadModel:
+    return PermissionReadModel(
+        id=permission.id,
+        name=permission.name,
+        description=permission.description,
+        scope=PermissionScope.GLOBAL,
+        company_id=None,
+    )
+
+
+def _company_permission_model(permission: CompanyPermission) -> PermissionReadModel:
+    return PermissionReadModel(
+        id=permission.id,
+        name=permission.name,
+        description=permission.description,
+        scope=PermissionScope.COMPANY,
+        company_id=permission.company_id,
+    )
+
+
+def _permission_sort_key(permission: PermissionReadModel) -> tuple[str, str, str]:
+    return (permission.scope.value, permission.name, str(permission.id))
+
+
+class GlobalPermissionRepository(BaseSQLRepository[GlobalPermission]):
+    model = GlobalPermission
+
+    def get_record(self, permission_id: UUID) -> GlobalPermission | None:
+        return (
+            self._base_query()
+            .filter(
+                GlobalPermission.id == permission_id,
+                GlobalPermission._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+
+    def ensure_record(self, permission_id: UUID) -> GlobalPermission:
+        permission = self.get_record(permission_id)
+        if permission is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PermissionResponseMessages.NOT_FOUND.value,
+            )
+        return permission
+
+    def create_permission(
+        self,
+        payload: PermissionCreateModel,
+        created_by,
+    ) -> PermissionReadModel:
+        permission = GlobalPermission(
+            name=payload.name,
+            description=payload.description,
+            primary_meta_data={"created_by": created_by.model_dump(mode="json")},
+        )
+        try:
+            self.db_session.add(permission)
+            self.db_session.commit()
+            self.db_session.refresh(permission)
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_EXISTS.value,
+            ) from exc
+        return _global_permission_model(permission)
+
+    def get_permissions(
+        self,
+        payload: PermissionQueryParamsModel,
+    ) -> PaginatedResponse[PermissionReadModel]:
+        query = self._base_query().filter(GlobalPermission._closed_at.is_(None))
+        if payload.name:
+            query = query.filter(GlobalPermission.name.ilike(f"%{payload.name}%"))
+        if payload.description:
+            query = query.filter(
+                GlobalPermission.description.ilike(f"%{payload.description}%")
+            )
+        total = query.count()
+        records = (
+            query.order_by(GlobalPermission.name.asc(), GlobalPermission.id.asc())
+            .offset((payload.page - 1) * payload.limit)
+            .limit(payload.limit)
+            .all()
+        )
+        from app.models.generic_pagination import build_pagination_meta
+
+        return PaginatedResponse[PermissionReadModel](
+            records=[_global_permission_model(record) for record in records],
+            pagination=build_pagination_meta(
+                total_records=total,
+                limit=payload.limit,
+                page=payload.page,
+            ),
+        )
+
+    def update_permission(
+        self,
+        permission_id: UUID,
+        payload: PermissionUpdateModel,
+    ) -> PermissionReadModel:
+        permission = self.ensure_record(permission_id)
+        if "name" in payload.model_fields_set:
+            permission.name = payload.name
+        if "description" in payload.model_fields_set:
+            permission.description = payload.description
+        try:
+            self.db_session.add(permission)
+            self.db_session.commit()
+            self.db_session.refresh(permission)
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_EXISTS.value,
+            ) from exc
+        return _global_permission_model(permission)
+
+    def delete_permission(self, permission_id: UUID) -> dict[str, str]:
+        permission = self.ensure_record(permission_id)
+        self.db_session.query(RoleGlobalPermission).filter(
+            RoleGlobalPermission.global_permission_id == permission_id
+        ).delete(synchronize_session=False)
+        self.db_session.delete(permission)
+        self.db_session.commit()
+        return {"message": f"Permission '{permission.name}' deleted successfully."}
+
+
+class CompanyPermissionRepository(BaseSQLRepository[CompanyPermission]):
+    model = CompanyPermission
+
+    def __init__(self, company_id: UUID, session: Session):
+        super().__init__(session)
+        self.company_id = company_id
+
+    def ensure_company(self) -> Company:
+        company = (
+            self.db_session.query(Company)
+            .filter(
+                Company.id == self.company_id,
+                Company._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+        if company is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message="Company not found.",
+            )
+        return company
+
+    def get_record(self, permission_id: UUID) -> CompanyPermission | None:
+        return (
+            self._base_query()
+            .filter(
+                CompanyPermission.company_id == self.company_id,
+                CompanyPermission.id == permission_id,
+                CompanyPermission._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+
+    def ensure_record(self, permission_id: UUID) -> CompanyPermission:
+        permission = self.get_record(permission_id)
+        if permission is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PermissionResponseMessages.NOT_FOUND.value,
+            )
+        return permission
+
+    def create_permission(
+        self,
+        payload: PermissionCreateModel,
+        created_by,
+    ) -> PermissionReadModel:
+        self.ensure_company()
+        permission = CompanyPermission(
+            company_id=self.company_id,
+            name=payload.name,
+            description=payload.description,
+            primary_meta_data={"created_by": created_by.model_dump(mode="json")},
+        )
+        try:
+            self.db_session.add(permission)
+            self.db_session.commit()
+            self.db_session.refresh(permission)
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_EXISTS.value,
+            ) from exc
+        return _company_permission_model(permission)
+
+    def get_permissions(
+        self,
+        payload: PermissionQueryParamsModel,
+    ) -> PaginatedResponse[PermissionReadModel]:
+        self.ensure_company()
+        query = self._base_query().filter(
+            CompanyPermission.company_id == self.company_id,
+            CompanyPermission._closed_at.is_(None),
+        )
+        if payload.name:
+            query = query.filter(CompanyPermission.name.ilike(f"%{payload.name}%"))
+        if payload.description:
+            query = query.filter(
+                CompanyPermission.description.ilike(f"%{payload.description}%")
+            )
+        total = query.count()
+        records = (
+            query.order_by(CompanyPermission.name.asc(), CompanyPermission.id.asc())
+            .offset((payload.page - 1) * payload.limit)
+            .limit(payload.limit)
+            .all()
+        )
+        from app.models.generic_pagination import build_pagination_meta
+
+        return PaginatedResponse[PermissionReadModel](
+            records=[_company_permission_model(record) for record in records],
+            pagination=build_pagination_meta(
+                total_records=total,
+                limit=payload.limit,
+                page=payload.page,
+            ),
+        )
+
+    def update_permission(
+        self,
+        permission_id: UUID,
+        payload: PermissionUpdateModel,
+    ) -> PermissionReadModel:
+        permission = self.ensure_record(permission_id)
+        if "name" in payload.model_fields_set:
+            permission.name = payload.name
+        if "description" in payload.model_fields_set:
+            permission.description = payload.description
+        try:
+            self.db_session.add(permission)
+            self.db_session.commit()
+            self.db_session.refresh(permission)
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_EXISTS.value,
+            ) from exc
+        return _company_permission_model(permission)
+
+    def delete_permission(self, permission_id: UUID) -> dict[str, str]:
+        permission = self.ensure_record(permission_id)
+        self.db_session.query(CompanyRolePermission).filter(
+            CompanyRolePermission.company_id == self.company_id,
+            CompanyRolePermission.company_permission_id == permission_id,
+        ).delete(synchronize_session=False)
+        self.db_session.delete(permission)
+        self.db_session.commit()
+        return {"message": f"Permission '{permission.name}' deleted successfully."}
+
+
+class RolePermissionRepository:
+    def __init__(self, session: Session):
+        self.db_session = session
+
+    def _ensure_role(self, role_id: UUID) -> Role:
+        role = (
+            self.db_session.query(Role)
+            .filter(Role.id == role_id, Role._closed_at.is_(None))
+            .one_or_none()
+        )
+        if role is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message="No role found with the given identifier.",
+            )
+        return role
+
+    def _ensure_company_role(self, company_id: UUID, role_id: UUID) -> CompanyRole:
+        assignment = (
+            self.db_session.query(CompanyRole)
+            .filter(
+                CompanyRole.company_id == company_id,
+                CompanyRole.role_id == role_id,
+                CompanyRole._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+        if assignment is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message="Role is not linked to the company.",
+            )
+        return assignment
+
+    def global_permissions_by_role_ids(
+        self,
+        role_ids: list[UUID] | set[UUID],
+    ) -> dict[UUID, list[PermissionReadModel]]:
+        result: dict[UUID, list[PermissionReadModel]] = defaultdict(list)
+        if not role_ids:
+            return result
+        rows = (
+            self.db_session.query(RoleGlobalPermission, GlobalPermission)
+            .join(
+                GlobalPermission,
+                GlobalPermission.id == RoleGlobalPermission.global_permission_id,
+            )
+            .filter(
+                RoleGlobalPermission.role_id.in_(role_ids),
+                RoleGlobalPermission._closed_at.is_(None),
+                GlobalPermission._closed_at.is_(None),
+            )
+            .all()
+        )
+        for link, permission in rows:
+            result[link.role_id].append(_global_permission_model(permission))
+        for permissions in result.values():
+            permissions.sort(key=_permission_sort_key)
+        return result
+
+    def effective_permissions_by_assignments(
+        self,
+        assignments: list[tuple[UUID, UUID]],
+    ) -> dict[tuple[UUID, UUID], list[PermissionReadModel]]:
+        pairs = list(dict.fromkeys(assignments))
+        result: dict[tuple[UUID, UUID], list[PermissionReadModel]] = {}
+        if not pairs:
+            return result
+        global_map = self.global_permissions_by_role_ids(
+            {role_id for _, role_id in pairs}
+        )
+        for company_id, role_id in pairs:
+            result[(company_id, role_id)] = list(global_map.get(role_id, []))
+
+        rows = (
+            self.db_session.query(CompanyRolePermission, CompanyPermission)
+            .join(
+                CompanyPermission,
+                tuple_(
+                    CompanyPermission.company_id,
+                    CompanyPermission.id,
+                )
+                == tuple_(
+                    CompanyRolePermission.company_id,
+                    CompanyRolePermission.company_permission_id,
+                ),
+            )
+            .filter(
+                tuple_(
+                    CompanyRolePermission.company_id,
+                    CompanyRolePermission.role_id,
+                ).in_(pairs),
+                CompanyRolePermission._closed_at.is_(None),
+                CompanyPermission._closed_at.is_(None),
+            )
+            .all()
+        )
+        for link, permission in rows:
+            result[(link.company_id, link.role_id)].append(
+                _company_permission_model(permission)
+            )
+        for permissions in result.values():
+            permissions.sort(key=_permission_sort_key)
+        return result
+
+    def get_global_role_permissions(self, role_id: UUID) -> list[PermissionReadModel]:
+        self._ensure_role(role_id)
+        return self.global_permissions_by_role_ids([role_id]).get(role_id, [])
+
+    def get_company_role_permissions(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+    ) -> list[PermissionReadModel]:
+        self._ensure_company_role(company_id, role_id)
+        return self.effective_permissions_by_assignments([(company_id, role_id)]).get(
+            (company_id, role_id),
+            [],
+        )
+
+    def global_role_read(self, role: Role) -> RoleReadModel:
+        return RoleReadModel(
+            id=str(role.id),
+            name=role.name,
+            description=role.description,
+            permissions=self.global_permissions_by_role_ids([role.id]).get(role.id, []),
+        )
+
+    def company_role_read(self, company_id: UUID, role: Role) -> RoleReadModel:
+        permissions = self.effective_permissions_by_assignments(
+            [(company_id, role.id)]
+        ).get((company_id, role.id), [])
+        return RoleReadModel(
+            id=str(role.id),
+            name=role.name,
+            description=role.description,
+            permissions=permissions,
+        )
+
+    def assign_global_permission(
+        self,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        role = self._ensure_role(role_id)
+        permission = GlobalPermissionRepository(self.db_session).ensure_record(
+            permission_id
+        )
+        existing = (
+            self.db_session.query(RoleGlobalPermission)
+            .filter_by(role_id=role_id, global_permission_id=permission.id)
+            .one_or_none()
+        )
+        if existing is not None:
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_ASSIGNED.value,
+            )
+        self.db_session.add(
+            RoleGlobalPermission(
+                role_id=role_id,
+                global_permission_id=permission.id,
+            )
+        )
+        self.db_session.commit()
+        return self.global_role_read(role)
+
+    def remove_global_permission(
+        self,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        role = self._ensure_role(role_id)
+        GlobalPermissionRepository(self.db_session).ensure_record(permission_id)
+        link = (
+            self.db_session.query(RoleGlobalPermission)
+            .filter_by(role_id=role_id, global_permission_id=permission_id)
+            .one_or_none()
+        )
+        if link is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PermissionResponseMessages.ASSIGNMENT_NOT_FOUND.value,
+            )
+        self.db_session.delete(link)
+        self.db_session.commit()
+        return self.global_role_read(role)
+
+    def assign_company_permission(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_company_role(company_id, role_id)
+        role = self._ensure_role(role_id)
+        permission = CompanyPermissionRepository(
+            company_id,
+            self.db_session,
+        ).ensure_record(permission_id)
+        existing = (
+            self.db_session.query(CompanyRolePermission)
+            .filter_by(
+                company_id=company_id,
+                role_id=role_id,
+                company_permission_id=permission.id,
+            )
+            .one_or_none()
+        )
+        if existing is not None:
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.ALREADY_ASSIGNED.value,
+            )
+        self.db_session.add(
+            CompanyRolePermission(
+                company_id=company_id,
+                role_id=role_id,
+                company_permission_id=permission.id,
+            )
+        )
+        try:
+            self.db_session.commit()
+        except IntegrityError as exc:
+            self.db_session.rollback()
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PermissionResponseMessages.NOT_FOUND.value,
+            ) from exc
+        return self.company_role_read(company_id, role)
+
+    def remove_company_permission(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_company_role(company_id, role_id)
+        role = self._ensure_role(role_id)
+        CompanyPermissionRepository(company_id, self.db_session).ensure_record(
+            permission_id
+        )
+        link = (
+            self.db_session.query(CompanyRolePermission)
+            .filter_by(
+                company_id=company_id,
+                role_id=role_id,
+                company_permission_id=permission_id,
+            )
+            .one_or_none()
+        )
+        if link is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PermissionResponseMessages.ASSIGNMENT_NOT_FOUND.value,
+            )
+        self.db_session.delete(link)
+        self.db_session.commit()
+        return self.company_role_read(company_id, role)
+
+
+class PlatformRoleRepository:
+    def __init__(self, session: Session):
+        self.db_session = session
+
+    def _ensure_active_user(self, user_id: UUID) -> User:
+        user = (
+            self.db_session.query(User)
+            .filter(User.id == user_id, User._closed_at.is_(None))
+            .one_or_none()
+        )
+        status_value = (user.primary_meta_data or {}).get("status") if user else None
+        if user is None or status_value != UserAccountStatus.ACTIVE.name_value:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message="No active user found with the given identifier.",
+            )
+        return user
+
+    def get_roles(self, user_id: UUID) -> list[RoleReadModel]:
+        self._ensure_active_user(user_id)
+        roles = (
+            self.db_session.query(Role)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .filter(
+                UserRole.user_id == user_id,
+                UserRole._closed_at.is_(None),
+                Role._closed_at.is_(None),
+            )
+            .order_by(Role.name.asc(), Role.id.asc())
+            .all()
+        )
+        permission_map = RolePermissionRepository(
+            self.db_session
+        ).global_permissions_by_role_ids({role.id for role in roles})
+        return [
+            RoleReadModel(
+                id=str(role.id),
+                name=role.name,
+                description=role.description,
+                permissions=permission_map.get(role.id, []),
+            )
+            for role in roles
+        ]
+
+    def assign_role(self, user_id: UUID, role_id: UUID) -> list[RoleReadModel]:
+        self._ensure_active_user(user_id)
+        RolePermissionRepository(self.db_session)._ensure_role(role_id)
+        existing = (
+            self.db_session.query(UserRole)
+            .filter_by(user_id=user_id, role_id=role_id)
+            .one_or_none()
+        )
+        if existing is not None:
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PlatformRoleResponseMessages.ALREADY_ASSIGNED.value,
+            )
+        self.db_session.add(UserRole(user_id=user_id, role_id=role_id))
+        self.db_session.commit()
+        return self.get_roles(user_id)
+
+    def remove_role(self, user_id: UUID, role_id: UUID) -> list[RoleReadModel]:
+        self._ensure_active_user(user_id)
+        link = (
+            self.db_session.query(UserRole)
+            .filter_by(user_id=user_id, role_id=role_id)
+            .one_or_none()
+        )
+        if link is None:
+            raise AppError(
+                status_code=status.HTTP_404_NOT_FOUND,
+                message=PlatformRoleResponseMessages.ASSIGNMENT_NOT_FOUND.value,
+            )
+        self.db_session.delete(link)
+        self.db_session.commit()
+        return self.get_roles(user_id)
+
+    def get_effective_permissions(self, user_id: UUID) -> list[PermissionReadModel]:
+        roles = self.get_roles(user_id)
+        permissions: dict[tuple[PermissionScope, UUID], PermissionReadModel] = {}
+        for role in roles:
+            for permission in role.permissions:
+                permissions[(permission.scope, permission.id)] = permission
+        return sorted(permissions.values(), key=_permission_sort_key)

--- a/app/repository/permission.py
+++ b/app/repository/permission.py
@@ -21,6 +21,11 @@ from app.models.permissions import (
     PermissionScope,
     PermissionUpdateModel,
 )
+from app.models.system_permissions import (
+    SYSTEM_PERMISSION_DEFINITIONS,
+    SystemPermissionDefinition,
+    is_system_permission_id,
+)
 from app.models.user.account_status import UserAccountStatus
 from app.repository.base import BaseSQLRepository
 from app.repository.database.tables import (
@@ -140,6 +145,15 @@ class GlobalPermissionRepository(BaseSQLRepository[GlobalPermission]):
         payload: PermissionUpdateModel,
     ) -> PermissionReadModel:
         permission = self.ensure_record(permission_id)
+        if (
+            is_system_permission_id(permission.id)
+            and "name" in payload.model_fields_set
+            and payload.name != permission.name
+        ):
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.SYSTEM_PERMISSION_PROTECTED.value,
+            )
         if "name" in payload.model_fields_set:
             permission.name = payload.name
         if "description" in payload.model_fields_set:
@@ -158,12 +172,90 @@ class GlobalPermissionRepository(BaseSQLRepository[GlobalPermission]):
 
     def delete_permission(self, permission_id: UUID) -> dict[str, str]:
         permission = self.ensure_record(permission_id)
+        if is_system_permission_id(permission.id):
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.SYSTEM_PERMISSION_PROTECTED.value,
+            )
         self.db_session.query(RoleGlobalPermission).filter(
             RoleGlobalPermission.global_permission_id == permission_id
         ).delete(synchronize_session=False)
         self.db_session.delete(permission)
         self.db_session.commit()
         return {"message": f"Permission '{permission.name}' deleted successfully."}
+
+
+class SystemPermissionRepository:
+    def __init__(self, session: Session):
+        self.db_session = session
+
+    def ensure_permissions(self) -> dict[UUID, GlobalPermission]:
+        permissions: dict[UUID, GlobalPermission] = {}
+        for definition in SYSTEM_PERMISSION_DEFINITIONS:
+            records = (
+                self.db_session.query(GlobalPermission)
+                .filter(
+                    (GlobalPermission.id == definition.id)
+                    | (GlobalPermission.name == definition.name)
+                )
+                .all()
+            )
+            permission = self._resolve_definition(definition, records)
+            if permission is None:
+                permission = GlobalPermission(
+                    id=definition.id,
+                    name=definition.name,
+                    description=definition.description,
+                    primary_meta_data={
+                        "system": True,
+                        "kind": "default_api_permission",
+                    },
+                )
+                self.db_session.add(permission)
+                self.db_session.flush()
+            permissions[definition.id] = permission
+        return permissions
+
+    def seed_new_default_roles(
+        self,
+        roles: dict[str, Role],
+        created_role_names: set[str],
+    ) -> None:
+        if not created_role_names:
+            return
+        permissions = self.ensure_permissions()
+        for definition in SYSTEM_PERMISSION_DEFINITIONS:
+            for role_name in definition.default_roles.intersection(created_role_names):
+                self.db_session.add(
+                    RoleGlobalPermission(
+                        role_id=roles[role_name].id,
+                        global_permission_id=permissions[definition.id].id,
+                        primary_meta_data={
+                            "system_default": True,
+                            "role": role_name,
+                        },
+                    )
+                )
+
+    @staticmethod
+    def _resolve_definition(
+        definition: SystemPermissionDefinition,
+        records: list[GlobalPermission],
+    ) -> GlobalPermission | None:
+        if not records:
+            return None
+        if len(records) != 1:
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.SYSTEM_PERMISSION_CONFLICT.value,
+            )
+        permission = records[0]
+        if permission.id != definition.id or permission.name != definition.name:
+            raise AppError(
+                status_code=status.HTTP_409_CONFLICT,
+                message=PermissionResponseMessages.SYSTEM_PERMISSION_CONFLICT.value,
+            )
+        return permission
 
 
 class CompanyPermissionRepository(BaseSQLRepository[CompanyPermission]):

--- a/app/services/company/authorization.py
+++ b/app/services/company/authorization.py
@@ -1,0 +1,70 @@
+from uuid import UUID
+
+from fastapi import status
+
+from app.models.company.response_messages import CompanyResponseMessages
+from app.models.system_permissions import SystemPermission
+from app.repository.database.tables import (
+    AssociationUserCompany,
+    Company,
+    CompanyRole,
+    GlobalPermission,
+    Role,
+    RoleGlobalPermission,
+)
+from app.utils.app_error import AppError
+from app.utils.shared_context import SharedContext
+
+
+class CompanyAuthorizationService:
+    def __init__(self, context: SharedContext):
+        self.context = context
+
+    def require(
+        self,
+        company_id: UUID,
+        permission: SystemPermission,
+    ) -> None:
+        if self.context.user.is_superuser:
+            return
+
+        authorized = (
+            self.context.db_session.query(AssociationUserCompany)
+            .join(
+                Company,
+                Company.id == AssociationUserCompany.company_id,
+            )
+            .join(
+                CompanyRole,
+                (CompanyRole.company_id == AssociationUserCompany.company_id)
+                & (CompanyRole.role_id == AssociationUserCompany.role_id),
+            )
+            .join(Role, Role.id == AssociationUserCompany.role_id)
+            .join(
+                RoleGlobalPermission,
+                RoleGlobalPermission.role_id == AssociationUserCompany.role_id,
+            )
+            .join(
+                GlobalPermission,
+                GlobalPermission.id == RoleGlobalPermission.global_permission_id,
+            )
+            .filter(
+                AssociationUserCompany.user_id == self.context.user.id,
+                AssociationUserCompany.company_id == company_id,
+                AssociationUserCompany._closed_at.is_(None),
+                Company._closed_at.is_(None),
+                CompanyRole._closed_at.is_(None),
+                Role._closed_at.is_(None),
+                RoleGlobalPermission._closed_at.is_(None),
+                GlobalPermission.id == permission.permission_id,
+                GlobalPermission.name == permission.value,
+                GlobalPermission._closed_at.is_(None),
+            )
+            .first()
+            is not None
+        )
+        if not authorized:
+            raise AppError(
+                status_code=status.HTTP_403_FORBIDDEN,
+                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
+            )

--- a/app/services/company/company.py
+++ b/app/services/company/company.py
@@ -6,7 +6,6 @@ from fastapi import status
 from app.utils.app_error import AppError
 
 # service and repository
-from app.services.company.user import CompanyUserService
 from app.repository.company import CompanyRepository
 
 # database
@@ -17,20 +16,19 @@ from app.models.company.company import (
     CompanyUpdateModel,
     CompanyReadModel,
 )
-from app.models.company.roles import CompanyDefaultRoles
-
-
 from app.utils.shared_context import SharedContext
 
 
 from app.models.company.response_messages import CompanyResponseMessages
+from app.models.system_permissions import SystemPermission
+from app.services.company.authorization import CompanyAuthorizationService
 
 
 class CompanyService:
     def __init__(self, context: SharedContext):
         self.context = context
         self.company_repository = CompanyRepository(context.db_session)
-        self.company_user_service = CompanyUserService(context)
+        self.authorization = CompanyAuthorizationService(context)
 
     def create_company(self, payload: CompanyCreateModel) -> CompanyReadModel:
         """
@@ -63,10 +61,7 @@ class CompanyService:
         if email:
             company = self.company_repository.get_company_by_email(email)
 
-        self.company_user_service.check_if_user_is_in_company(
-            user_id=self.context.user.id,
-            company_id=company.id,
-        )
+        self.authorization.require(company.id, SystemPermission.COMPANY_READ)
 
         return company
 
@@ -76,22 +71,7 @@ class CompanyService:
         """
         Update a company by its ID.
         """
-        if not (
-            self.company_user_service.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role=CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-            or self.company_user_service.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role=CompanyDefaultRoles.OWNER.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
-            )
+        self.authorization.require(company_id, SystemPermission.COMPANY_UPDATE)
 
         company = self.company_repository.update_company(
             payload, company_id, self.context.user
@@ -104,9 +84,5 @@ class CompanyService:
         return company
 
     def delete_company(self, company_id: UUID) -> None:
-        self.company_user_service.check_if_user_is_in_company(
-            user_id=self.context.user.id,
-            company_id=company_id,
-            role=CompanyDefaultRoles.OWNER.name_value,
-        )
+        self.authorization.require(company_id, SystemPermission.COMPANY_DELETE)
         self.company_repository.delete_company(company_id)

--- a/app/services/company/role.py
+++ b/app/services/company/role.py
@@ -4,7 +4,6 @@ from fastapi import status
 
 from app.models.company.response_messages import CompanyRoleResponseMessages
 from app.models.company.roles import (
-    CompanyDefaultRoles,
     RoleAssignCompaniesModel,
     RoleCreateModel,
     RoleDeleteModel,
@@ -12,12 +11,13 @@ from app.models.company.roles import (
     RoleReadModel,
     RoleUpdateModel,
 )
+from app.models.system_permissions import SystemPermission
 from app.models.generic_pagination import PaginatedResponse
 from app.repository.company_role import (
     CompanyRoleAssignmentRepository,
     RoleRepository,
 )
-from app.services.company.user import CompanyUserService
+from app.services.company.authorization import CompanyAuthorizationService
 from app.utils.app_error import AppError
 from app.utils.shared_context import SharedContext
 
@@ -25,6 +25,7 @@ from app.utils.shared_context import SharedContext
 class RoleService:
     def __init__(self, context: SharedContext):
         self.context = context
+        self.authorization = CompanyAuthorizationService(context)
 
     def _ensure_superuser(self) -> None:
         if not self.context.user.is_superuser:
@@ -33,24 +34,12 @@ class RoleService:
                 message=CompanyRoleResponseMessages.ROLE_MANAGEMENT_FORBIDDEN.value,
             )
 
-    def _ensure_company_manager(self, company_id: UUID) -> None:
-        company_user_service = CompanyUserService(self.context)
-        if not (
-            company_user_service.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-            or company_user_service.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.OWNER.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message="Access denied. You are not authorized to access this company.",
-            )
+    def _ensure_company_permission(
+        self,
+        company_id: UUID,
+        permission: SystemPermission,
+    ) -> None:
+        self.authorization.require(company_id, permission)
 
     def create_role(
         self, payload: RoleCreateModel, company_id: UUID | None = None
@@ -120,7 +109,10 @@ class RoleService:
         )
 
     def assign_role_to_company(self, company_id: UUID, role_id: UUID) -> RoleReadModel:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_ROLES_ASSIGN,
+        )
         role = RoleRepository(self.context.db_session).ensure_role_exists(role_id)
         return CompanyRoleAssignmentRepository(
             company_id=company_id,
@@ -154,7 +146,10 @@ class RoleService:
         ).assign_role(role_record, self.context.user)
 
     def unassign_role(self, company_id: UUID, role_id: UUID) -> dict:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_ROLES_UNASSIGN,
+        )
         return CompanyRoleAssignmentRepository(
             company_id=company_id,
             session=self.context.db_session,
@@ -170,7 +165,10 @@ class RoleService:
     def get_company_roles(
         self, payload: RoleQueryParamsModel, company_id: UUID
     ) -> PaginatedResponse[RoleReadModel]:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_ROLES_READ,
+        )
         result = CompanyRoleAssignmentRepository(
             company_id=company_id,
             session=self.context.db_session,

--- a/app/services/company/user.py
+++ b/app/services/company/user.py
@@ -15,13 +15,14 @@ from app.models.generic_pagination import PaginatedResponse
 from app.utils.app_error import AppError
 
 from app.models.company.roles import CompanyDefaultRoles
+from app.models.system_permissions import SystemPermission
+from app.services.company.authorization import CompanyAuthorizationService
 
 
 from app.models.user.user import UserQueryParams
 
 
 from app.models.company.response_messages import (
-    CompanyResponseMessages,
     CompanyUserResponseMessages,
 )
 from app.utils.shared_context import SharedContext
@@ -35,6 +36,7 @@ class CompanyUserService:
         self.context = context
         self.company_user_repository = CompanyUserRepository(context.db_session)
         self.company_repository = CompanyRepository(context.db_session)
+        self.authorization = CompanyAuthorizationService(context)
 
     def send_company_invite(
         self,
@@ -72,22 +74,10 @@ class CompanyUserService:
     def add_user_to_company(
         self, company_id: UUID, payload: CompanyUserAddModel
     ) -> CompanyUserReadModel:
-        if not (
-            self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-            or self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.OWNER.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
-            )
+        self.authorization.require(
+            company_id,
+            SystemPermission.COMPANY_MEMBERS_ADD,
+        )
         user = self.company_user_repository.add_user_to_company(
             company_id=company_id, payload=payload, added_by=self.context.user
         )
@@ -107,22 +97,10 @@ class CompanyUserService:
         user_id: UUID,
         payload: CompanyUserRoleUpdateModel,
     ) -> CompanyUserReadModel:
-        if not (
-            self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-            or self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.OWNER.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
-            )
+        self.authorization.require(
+            company_id,
+            SystemPermission.COMPANY_MEMBERS_ROLE_UPDATE,
+        )
         return self.company_user_repository.update_user_role(
             company_id=company_id,
             user_id=user_id,
@@ -135,22 +113,10 @@ class CompanyUserService:
         company_id: UUID,
         user_id: UUID,
     ) -> CompanyUserReadModel:
-        if not (
-            self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-            or self.company_user_repository.is_user_linked_to_company(
-                user_id=self.context.user.id,
-                company_id=company_id,
-                role_name=CompanyDefaultRoles.OWNER.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
-            )
+        self.authorization.require(
+            company_id,
+            SystemPermission.COMPANY_MEMBERS_REMOVE,
+        )
         if self.company_user_repository.is_user_linked_to_company(
             user_id=user_id,
             company_id=company_id,
@@ -172,30 +138,11 @@ class CompanyUserService:
         company_id: UUID,
         params: UserQueryParams,
     ) -> PaginatedResponse[CompanyUserReadModel]:
-        self.check_if_user_is_in_company(
-            user_id=self.context.user.id,
-            company_id=company_id,
+        self.authorization.require(
+            company_id,
+            SystemPermission.COMPANY_MEMBERS_READ,
         )
         return self.company_user_repository.get_company_users(
             company_id=company_id,
             params=params,
         )
-
-    def check_if_user_is_in_company(
-        self, user_id: UUID, company_id: UUID, role: str | None = None
-    ) -> bool:
-        """
-        Check if the user is linked to the company.
-        If a role is provided, check if the user has that role.
-        """
-        linked_company = self.company_user_repository.is_user_linked_to_company(
-            user_id=user_id,
-            company_id=company_id,
-            role_name=role,
-        )
-        if not linked_company:
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=CompanyResponseMessages.UNAUTHORIZED_COMPANY_ACCESS.value,
-            )
-        return linked_company

--- a/app/services/permission.py
+++ b/app/services/permission.py
@@ -1,0 +1,232 @@
+from uuid import UUID
+
+from fastapi import status
+
+from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
+from app.models.generic_pagination import PaginatedResponse
+from app.models.permission_response_messages import PermissionResponseMessages
+from app.models.permissions import (
+    PermissionCreateModel,
+    PermissionQueryParamsModel,
+    PermissionReadModel,
+    PermissionUpdateModel,
+)
+from app.repository.company_user import CompanyUserRepository
+from app.repository.permission import (
+    CompanyPermissionRepository,
+    GlobalPermissionRepository,
+    PlatformRoleRepository,
+    RolePermissionRepository,
+)
+from app.utils.app_error import AppError
+from app.utils.shared_context import SharedContext
+
+
+class PermissionService:
+    def __init__(self, context: SharedContext):
+        self.context = context
+
+    def _ensure_superuser(self) -> None:
+        if not self.context.user.is_superuser:
+            raise AppError(
+                status_code=status.HTTP_403_FORBIDDEN,
+                message=PermissionResponseMessages.MANAGEMENT_FORBIDDEN.value,
+            )
+
+    def _ensure_company_manager(self, company_id: UUID) -> None:
+        repository = CompanyPermissionRepository(
+            company_id,
+            self.context.db_session,
+        )
+        repository.ensure_company()
+        if self.context.user.is_superuser:
+            return
+        company_users = CompanyUserRepository(self.context.db_session)
+        if not (
+            company_users.is_user_linked_to_company(
+                self.context.user.id,
+                company_id,
+                CompanyDefaultRoles.OWNER.name_value,
+            )
+            or company_users.is_user_linked_to_company(
+                self.context.user.id,
+                company_id,
+                CompanyDefaultRoles.ADMINISTRATOR.name_value,
+            )
+        ):
+            raise AppError(
+                status_code=status.HTTP_403_FORBIDDEN,
+                message=PermissionResponseMessages.MANAGEMENT_FORBIDDEN.value,
+            )
+
+    def create_global_permission(
+        self,
+        payload: PermissionCreateModel,
+    ) -> PermissionReadModel:
+        self._ensure_superuser()
+        return GlobalPermissionRepository(self.context.db_session).create_permission(
+            payload, self.context.user
+        )
+
+    def get_global_permissions(
+        self,
+        payload: PermissionQueryParamsModel,
+    ) -> PaginatedResponse[PermissionReadModel]:
+        self._ensure_superuser()
+        return GlobalPermissionRepository(self.context.db_session).get_permissions(
+            payload
+        )
+
+    def update_global_permission(
+        self,
+        permission_id: UUID,
+        payload: PermissionUpdateModel,
+    ) -> PermissionReadModel:
+        self._ensure_superuser()
+        return GlobalPermissionRepository(self.context.db_session).update_permission(
+            permission_id,
+            payload,
+        )
+
+    def delete_global_permission(self, permission_id: UUID) -> dict[str, str]:
+        self._ensure_superuser()
+        return GlobalPermissionRepository(self.context.db_session).delete_permission(
+            permission_id
+        )
+
+    def create_company_permission(
+        self,
+        company_id: UUID,
+        payload: PermissionCreateModel,
+    ) -> PermissionReadModel:
+        self._ensure_company_manager(company_id)
+        return CompanyPermissionRepository(
+            company_id,
+            self.context.db_session,
+        ).create_permission(payload, self.context.user)
+
+    def get_company_permissions(
+        self,
+        company_id: UUID,
+        payload: PermissionQueryParamsModel,
+    ) -> PaginatedResponse[PermissionReadModel]:
+        self._ensure_company_manager(company_id)
+        return CompanyPermissionRepository(
+            company_id,
+            self.context.db_session,
+        ).get_permissions(payload)
+
+    def update_company_permission(
+        self,
+        company_id: UUID,
+        permission_id: UUID,
+        payload: PermissionUpdateModel,
+    ) -> PermissionReadModel:
+        self._ensure_company_manager(company_id)
+        return CompanyPermissionRepository(
+            company_id,
+            self.context.db_session,
+        ).update_permission(permission_id, payload)
+
+    def delete_company_permission(
+        self,
+        company_id: UUID,
+        permission_id: UUID,
+    ) -> dict[str, str]:
+        self._ensure_company_manager(company_id)
+        return CompanyPermissionRepository(
+            company_id,
+            self.context.db_session,
+        ).delete_permission(permission_id)
+
+    def get_global_role_permissions(
+        self,
+        role_id: UUID,
+    ) -> list[PermissionReadModel]:
+        self._ensure_superuser()
+        return RolePermissionRepository(
+            self.context.db_session
+        ).get_global_role_permissions(role_id)
+
+    def assign_global_permission(
+        self,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_superuser()
+        return RolePermissionRepository(
+            self.context.db_session
+        ).assign_global_permission(role_id, permission_id)
+
+    def remove_global_permission(
+        self,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_superuser()
+        return RolePermissionRepository(
+            self.context.db_session
+        ).remove_global_permission(role_id, permission_id)
+
+    def get_company_role_permissions(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+    ) -> list[PermissionReadModel]:
+        self._ensure_company_manager(company_id)
+        return RolePermissionRepository(
+            self.context.db_session
+        ).get_company_role_permissions(company_id, role_id)
+
+    def assign_company_permission(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_company_manager(company_id)
+        return RolePermissionRepository(
+            self.context.db_session
+        ).assign_company_permission(company_id, role_id, permission_id)
+
+    def remove_company_permission(
+        self,
+        company_id: UUID,
+        role_id: UUID,
+        permission_id: UUID,
+    ) -> RoleReadModel:
+        self._ensure_company_manager(company_id)
+        return RolePermissionRepository(
+            self.context.db_session
+        ).remove_company_permission(company_id, role_id, permission_id)
+
+    def get_platform_roles(self, user_id: UUID) -> list[RoleReadModel]:
+        self._ensure_superuser()
+        return PlatformRoleRepository(self.context.db_session).get_roles(user_id)
+
+    def assign_platform_role(
+        self,
+        user_id: UUID,
+        role_id: UUID,
+    ) -> list[RoleReadModel]:
+        self._ensure_superuser()
+        return PlatformRoleRepository(self.context.db_session).assign_role(
+            user_id,
+            role_id,
+        )
+
+    def remove_platform_role(
+        self,
+        user_id: UUID,
+        role_id: UUID,
+    ) -> list[RoleReadModel]:
+        self._ensure_superuser()
+        return PlatformRoleRepository(self.context.db_session).remove_role(
+            user_id,
+            role_id,
+        )
+
+    def get_my_platform_permissions(self) -> list[PermissionReadModel]:
+        return PlatformRoleRepository(
+            self.context.db_session
+        ).get_effective_permissions(self.context.user.id)

--- a/app/services/permission.py
+++ b/app/services/permission.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import status
 
-from app.models.company.roles import CompanyDefaultRoles, RoleReadModel
+from app.models.company.roles import RoleReadModel
 from app.models.generic_pagination import PaginatedResponse
 from app.models.permission_response_messages import PermissionResponseMessages
 from app.models.permissions import (
@@ -11,7 +11,7 @@ from app.models.permissions import (
     PermissionReadModel,
     PermissionUpdateModel,
 )
-from app.repository.company_user import CompanyUserRepository
+from app.models.system_permissions import SystemPermission
 from app.repository.permission import (
     CompanyPermissionRepository,
     GlobalPermissionRepository,
@@ -20,11 +20,13 @@ from app.repository.permission import (
 )
 from app.utils.app_error import AppError
 from app.utils.shared_context import SharedContext
+from app.services.company.authorization import CompanyAuthorizationService
 
 
 class PermissionService:
     def __init__(self, context: SharedContext):
         self.context = context
+        self.company_authorization = CompanyAuthorizationService(context)
 
     def _ensure_superuser(self) -> None:
         if not self.context.user.is_superuser:
@@ -33,31 +35,17 @@ class PermissionService:
                 message=PermissionResponseMessages.MANAGEMENT_FORBIDDEN.value,
             )
 
-    def _ensure_company_manager(self, company_id: UUID) -> None:
+    def _ensure_company_permission(
+        self,
+        company_id: UUID,
+        permission: SystemPermission,
+    ) -> None:
         repository = CompanyPermissionRepository(
             company_id,
             self.context.db_session,
         )
         repository.ensure_company()
-        if self.context.user.is_superuser:
-            return
-        company_users = CompanyUserRepository(self.context.db_session)
-        if not (
-            company_users.is_user_linked_to_company(
-                self.context.user.id,
-                company_id,
-                CompanyDefaultRoles.OWNER.name_value,
-            )
-            or company_users.is_user_linked_to_company(
-                self.context.user.id,
-                company_id,
-                CompanyDefaultRoles.ADMINISTRATOR.name_value,
-            )
-        ):
-            raise AppError(
-                status_code=status.HTTP_403_FORBIDDEN,
-                message=PermissionResponseMessages.MANAGEMENT_FORBIDDEN.value,
-            )
+        self.company_authorization.require(company_id, permission)
 
     def create_global_permission(
         self,
@@ -99,7 +87,10 @@ class PermissionService:
         company_id: UUID,
         payload: PermissionCreateModel,
     ) -> PermissionReadModel:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_CREATE,
+        )
         return CompanyPermissionRepository(
             company_id,
             self.context.db_session,
@@ -110,7 +101,10 @@ class PermissionService:
         company_id: UUID,
         payload: PermissionQueryParamsModel,
     ) -> PaginatedResponse[PermissionReadModel]:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_READ,
+        )
         return CompanyPermissionRepository(
             company_id,
             self.context.db_session,
@@ -122,7 +116,10 @@ class PermissionService:
         permission_id: UUID,
         payload: PermissionUpdateModel,
     ) -> PermissionReadModel:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_UPDATE,
+        )
         return CompanyPermissionRepository(
             company_id,
             self.context.db_session,
@@ -133,7 +130,10 @@ class PermissionService:
         company_id: UUID,
         permission_id: UUID,
     ) -> dict[str, str]:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_DELETE,
+        )
         return CompanyPermissionRepository(
             company_id,
             self.context.db_session,
@@ -173,7 +173,10 @@ class PermissionService:
         company_id: UUID,
         role_id: UUID,
     ) -> list[PermissionReadModel]:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_READ,
+        )
         return RolePermissionRepository(
             self.context.db_session
         ).get_company_role_permissions(company_id, role_id)
@@ -184,7 +187,10 @@ class PermissionService:
         role_id: UUID,
         permission_id: UUID,
     ) -> RoleReadModel:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_ASSIGN,
+        )
         return RolePermissionRepository(
             self.context.db_session
         ).assign_company_permission(company_id, role_id, permission_id)
@@ -195,7 +201,10 @@ class PermissionService:
         role_id: UUID,
         permission_id: UUID,
     ) -> RoleReadModel:
-        self._ensure_company_manager(company_id)
+        self._ensure_company_permission(
+            company_id,
+            SystemPermission.COMPANY_PERMISSIONS_UNASSIGN,
+        )
         return RolePermissionRepository(
             self.context.db_session
         ).remove_company_permission(company_id, role_id, permission_id)

--- a/app/services/superuser_bootstrap.py
+++ b/app/services/superuser_bootstrap.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func, update
+from sqlalchemy.orm import Session
+
+from app.models.user.account_status import UserAccountStatus
+from app.repository.database.tables import (
+    PrivilegedAccessEvent,
+    SuperuserBootstrapControl,
+    User,
+)
+
+
+class SuperuserBootstrapError(RuntimeError):
+    """Raised when the one-time superuser bootstrap cannot safely proceed."""
+
+
+@dataclass(frozen=True)
+class SuperuserBootstrapCandidate:
+    user_id: UUID
+    email: str
+
+
+@dataclass(frozen=True)
+class SuperuserBootstrapResult:
+    user_id: UUID
+    changed: bool
+
+
+class SuperuserBootstrapService:
+    ACTION = "superuser_bootstrapped"
+    SOURCE = "operator_cli"
+    MAX_REASON_LENGTH = 1024
+
+    def __init__(self, session: Session):
+        self.db_session = session
+
+    @staticmethod
+    def _normalize_email(email: str) -> str:
+        normalized = email.strip().lower()
+        if not normalized:
+            raise SuperuserBootstrapError("An existing user's email is required.")
+        return normalized
+
+    def _get_target(self, email: str) -> User:
+        normalized_email = self._normalize_email(email)
+        user = (
+            self.db_session.query(User)
+            .filter(
+                func.lower(User.email) == normalized_email,
+                User._closed_at.is_(None),
+            )
+            .one_or_none()
+        )
+        if user is None:
+            raise SuperuserBootstrapError(
+                "No active user exists for the supplied email. Register and verify "
+                "the account before bootstrapping."
+            )
+        status = (user.primary_meta_data or {}).get("status")
+        if status != UserAccountStatus.ACTIVE.name_value:
+            raise SuperuserBootstrapError(
+                "The bootstrap target must be active and verified."
+            )
+        return user
+
+    def get_candidate(self, email: str) -> SuperuserBootstrapCandidate:
+        user = self._get_target(email)
+        return SuperuserBootstrapCandidate(user_id=user.id, email=user.email)
+
+    def _lock_control(self) -> SuperuserBootstrapControl:
+        lock_result = self.db_session.execute(
+            update(SuperuserBootstrapControl)
+            .where(
+                SuperuserBootstrapControl.id == SuperuserBootstrapControl.SINGLETON_ID
+            )
+            .values(_updated_at=datetime.now(timezone.utc))
+        )
+        if lock_result.rowcount != 1:
+            raise SuperuserBootstrapError(
+                "Superuser bootstrap control is missing. Apply Alembic migrations "
+                "before running this command."
+            )
+        return (
+            self.db_session.query(SuperuserBootstrapControl)
+            .filter_by(id=SuperuserBootstrapControl.SINGLETON_ID)
+            .with_for_update()
+            .one()
+        )
+
+    @classmethod
+    def _validate_reason(cls, reason: str) -> str:
+        normalized = reason.strip()
+        if not normalized:
+            raise SuperuserBootstrapError("A bootstrap reason is required.")
+        if len(normalized) > cls.MAX_REASON_LENGTH:
+            raise SuperuserBootstrapError(
+                f"The bootstrap reason cannot exceed {cls.MAX_REASON_LENGTH} characters."
+            )
+        return normalized
+
+    def bootstrap(
+        self,
+        *,
+        email: str,
+        reason: str,
+        expected_user_id: UUID,
+    ) -> SuperuserBootstrapResult:
+        normalized_reason = self._validate_reason(reason)
+        try:
+            control = self._lock_control()
+            target = self._get_target(email)
+            if target.id != expected_user_id:
+                raise SuperuserBootstrapError(
+                    "The confirmed user ID no longer matches the requested account."
+                )
+
+            if control.bootstrap_completed_at is not None:
+                if control.bootstrap_user_id == target.id and target.is_superuser:
+                    self.db_session.rollback()
+                    return SuperuserBootstrapResult(
+                        user_id=target.id,
+                        changed=False,
+                    )
+                raise SuperuserBootstrapError(
+                    "Initial superuser bootstrap has already been completed. Future "
+                    "changes must use the superuser administration workflow."
+                )
+
+            existing_superuser = (
+                self.db_session.query(User).filter(User.is_superuser.is_(True)).first()
+            )
+            if existing_superuser is not None:
+                raise SuperuserBootstrapError(
+                    "A superuser already exists, so initial bootstrap is disabled."
+                )
+
+            metadata = dict(target.primary_meta_data or {})
+            try:
+                refresh_token_version = int(metadata.get("refresh_token_version", 0))
+            except (TypeError, ValueError):
+                refresh_token_version = 0
+            metadata["refresh_token_version"] = refresh_token_version + 1
+            target.primary_meta_data = metadata
+            target.is_superuser = True
+
+            completed_at = datetime.now(timezone.utc)
+            control.bootstrap_user_id = target.id
+            control.bootstrap_completed_at = completed_at
+            control.bootstrap_method = self.SOURCE
+            self.db_session.add(
+                PrivilegedAccessEvent(
+                    actor_user_id=None,
+                    target_user_id=target.id,
+                    action=self.ACTION,
+                    source=self.SOURCE,
+                    reason=normalized_reason,
+                    previous_superuser=False,
+                    resulting_superuser=True,
+                    request_id=None,
+                    primary_meta_data={},
+                    secondary_meta_data={},
+                )
+            )
+            self.db_session.commit()
+            return SuperuserBootstrapResult(user_id=target.id, changed=True)
+        except Exception:
+            self.db_session.rollback()
+            raise

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,4 +39,4 @@ When `TESTING=true` or `ENVIRONMENT=testing`, SMTP delivery is skipped so tests 
 
 ## How is coverage configured?
 
-Coverage is configured in `pyproject.toml` under `[tool.coverage.*]`. CI enforces `96%` coverage and writes XML output to `coverage_reports/coverage.xml`.
+Coverage is configured in `pyproject.toml` under `[tool.coverage.*]`. CI enforces `100%` statement coverage and writes XML output to `coverage_reports/coverage.xml`.

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -51,10 +51,10 @@ That script currently:
 uv run pytest -v --cov=app \
   --cov-report=term-missing \
   --cov-report=xml:coverage_reports/coverage.xml \
-  --cov-fail-under=96
+  --cov-fail-under=100
 ```
 
-Coverage must stay at or above `96%` or the job fails.
+Statement coverage must remain at `100%` or the job fails.
 
 ### Formatting behavior
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,6 @@ Start with:
 - [Configuration](configuration.md) for runtime environment variables and database setup.
 - [Testing](testing.md) for pytest, coverage commands, and env-backed HTTP test runs.
 - [GitHub Workflows](github-workflows.md) for CI, release automation, and workflow improvement notes.
+- [Potential Provider-Neutral Authorization Roadmap](potential/provider-neutral-authorization-roadmap.md)
+  for proposed security, membership, authorization, and bring-your-own-identity work.
 - [FAQ](faq.md) for common local development issues.

--- a/docs/potential/provider-neutral-authorization-roadmap.md
+++ b/docs/potential/provider-neutral-authorization-roadmap.md
@@ -305,20 +305,24 @@ endpoint.
 Define an authorization schema that preserves the global role catalog while
 making company context explicit.
 
-**Recommended model**
+**Implemented foundation**
 
-- `permission`: global immutable key such as `invoice.approve`, plus display
-  metadata.
-- `role`: reusable global role template.
-- `role_permission`: permissions supplied by a role template.
-- `company_role`: roles enabled for a company.
-- A membership-to-role join table so a membership can hold multiple enabled
-  company roles.
+- `global_permission`: application-wide permissions supplied by reusable global
+  roles.
+- `company_permission`: tenant-owned permissions that can be added to a role in
+  one company only.
+- `role_global_permission`: the mandatory global permission baseline for a role.
+- `company_role_permission`: additive company permissions, constrained to an
+  enabled role and permission from the same company.
+- `user_role`: direct platform role assignments that contribute global
+  permissions but never imply company membership.
+- `company_role`: global roles enabled for a company. A company membership still
+  holds one enabled role in the initial implementation.
 
 **Work**
 
-- Decide whether companies can override a global role template. Defer overrides
-  in v1 unless a concrete use case requires them.
+- Keep global permissions mandatory and company permissions additive. Defer
+  tenant overrides and deny rules until a concrete use case requires them.
 - Define names, keys, deletion behavior, and versioning for roles and
   permissions.
 - Migrate the current single `association_user_company.role_id` safely.
@@ -332,7 +336,8 @@ making company context explicit.
 
 **Look out for**
 
-- Assuming a globally shared role can be edited independently by each company.
+- Assuming a globally shared role or its global permission baseline can be
+  edited independently by each company.
 - Role-name authorization checks; use stable IDs and permission keys.
 - Soft-delete uniqueness preventing a safe recreation or causing an old record
   to regain authority.
@@ -746,8 +751,10 @@ Give company administrators practical, safe self-service workflows.
 - The current global role catalog means a role definition may be shared by
   multiple companies. Confirm that every role mutation has the intended global
   effect.
-- Do not add permissions until template-versus-company ownership is settled.
-- Use permission keys in code; display names may change.
+- Keep platform role assignments separate from company membership; platform
+  permissions alone must never authorize tenant data.
+- Permission identity includes its global or company scope; display names may
+  change and can overlap across scopes.
 
 ### Database portability and concurrency
 

--- a/docs/potential/provider-neutral-authorization-roadmap.md
+++ b/docs/potential/provider-neutral-authorization-roadmap.md
@@ -1,0 +1,840 @@
+# Potential Roadmap: Provider-Neutral B2B Authorization
+
+Status: **proposed; not committed**
+
+This roadmap describes how Userverse could become a secure, self-hosted B2B
+membership and authorization control plane without becoming an OAuth 2.0
+Authorization Server or OpenID Connect Provider.
+
+The intended product position is:
+
+> Userverse keeps company membership and authorization consistent across
+> authentication providers and gives applications simple, current, auditable
+> access decisions.
+
+Applications remain responsible for interactive authentication, or use an
+existing identity provider. Userverse owns stable internal user identities,
+company membership, roles, permissions, access decisions, and audit history.
+
+## Why this direction
+
+Organizations, roles, and login are already offered together by large identity
+platforms. Rebuilding their protocol surface would give Userverse a large
+security burden without creating a clear distinction. Userverse can instead be
+valuable as the independent domain layer that survives a change of identity
+provider.
+
+This direction should provide:
+
+- Stable Userverse user and company IDs that do not change during an IdP
+  migration.
+- Explicit membership lifecycle and immediate offboarding.
+- Company-scoped roles and permissions that are evaluated from current data.
+- Explainable allow/deny decisions and a useful audit trail.
+- A small operational footprint and a straightforward developer experience.
+
+This direction does **not** include:
+
+- OAuth 2.0 authorization-server endpoints, consent, client registration, or
+  third-party token issuance.
+- OpenID Connect Provider discovery or ID tokens.
+- SAML, SCIM, enterprise identity brokering, or a general policy language in
+  the first release.
+- Automatic account linking based only on matching email addresses.
+
+## Target architecture
+
+```text
+Authentication provider
+        |
+        | signed identity token
+        v
+Application / Userverse trusted-token boundary
+        |
+        | validated (issuer, subject) identity
+        v
+Userverse identity link -> company membership -> roles -> permissions
+                                                   |
+                                                   v
+                                  allow/deny decision + explanation
+                                                   |
+                                                   v
+                                             audit event
+```
+
+The main security boundary is between authentication and authorization:
+
+- Authentication establishes who the external subject is.
+- An `identity_link` maps `(issuer, subject)` to a stable Userverse user.
+- The requested company is treated as authorization context, not identity.
+- Userverse evaluates current membership and permission records for every
+  sensitive decision.
+- Token claims may identify a subject but are not authoritative for current
+  Userverse roles or membership state.
+
+## Roadmap overview
+
+Estimates are engineering-effort ranges, not delivery commitments. They assume
+one engineer familiar with the existing FastAPI and SQLAlchemy codebase.
+
+| Milestone | Outcome | Tickets | Estimate |
+| --- | --- | --- | --- |
+| 0. Boundaries and baseline | Agreed security and product invariants | UV-ACP-001 to 003 | 1-2 weeks |
+| 1. Secure identity foundation | Truthful identities and revocable sessions | UV-SEC-001 to 004 | 3-5 weeks |
+| 2. Authorization product | Current, explainable tenant-scoped decisions | UV-AUTHZ-001 to 006 | 5-8 weeks |
+| 3. Bring-your-own identity | Strict inbound validation and safe identity linking | UV-IDP-001 to 004 | 3-5 weeks |
+| 4. Adoption and operations | SDK, webhooks, access reviews, and examples | UV-DX-001 to 004 | 4-7 weeks |
+
+Milestones should be delivered in order. Do not start external identity-provider
+integration until the internal identity, membership, and tenant-isolation rules
+are stable.
+
+## Milestone 0: Boundaries and baseline
+
+### UV-ACP-001: Record the product and protocol boundary
+
+**Goal**
+
+Create an architecture decision record stating that Userverse is an
+authorization and membership system, not an OAuth/OIDC provider.
+
+**Work**
+
+- Define the authentication systems Userverse trusts and the data Userverse
+  owns.
+- Define stable identifiers for users, companies, memberships, and external
+  identities.
+- Document how applications authenticate to Userverse separately from how an
+  end-user identity is established.
+- Document which OAuth/OIDC responsibilities remain outside Userverse.
+
+**Acceptance criteria**
+
+- The trust boundary and non-goals are unambiguous.
+- There is no proposed endpoint that exchanges an external identity token for
+  a general-purpose third-party access token.
+- Userverse user IDs remain stable when external identity providers change.
+
+**Look out for**
+
+- Accidentally designing token exchange or delegated authorization and calling
+  it "identity validation." That would move Userverse back toward being an
+  authorization server.
+- Treating an email address as a permanent identity key.
+
+### UV-ACP-002: Produce a tenant-aware threat model
+
+**Goal**
+
+Document threats and required controls before adding new authorization paths.
+
+**Work**
+
+- Model IDOR and cross-company access, confused-deputy behavior, privilege
+  escalation, stale permissions, account linking, session theft, malicious
+  issuer configuration, signing-key substitution, and audit-log leakage.
+- Define security invariants and map each invariant to tests and monitoring.
+- Identify actions that require reauthentication or administrator approval.
+
+**Acceptance criteria**
+
+- Every sensitive operation has an actor, company, required permission, and
+  audit requirement.
+- Cross-company failure cases are documented alongside successful cases.
+- Each high-risk threat has a preventative or detective control.
+
+**Look out for**
+
+- Focusing only on token validation. Most likely failures will be tenant
+  filtering, membership state, or administrative authorization mistakes.
+- Superuser behavior bypassing audit or company-scope checks invisibly.
+
+### UV-ACP-003: Establish security regression and migration gates
+
+**Goal**
+
+Create shared checks that all later tickets must satisfy.
+
+**Work**
+
+- Add a reusable cross-company test matrix for users, memberships, roles, and
+  future permission checks.
+- Add migration tests for SQLite and the production database engines supported
+  by Userverse.
+- Define compatibility checks for existing HTTP response shapes and first-party
+  authentication.
+
+**Acceptance criteria**
+
+- A test fails when a user from company A can read or mutate company B data.
+- Forward migrations work against a representative pre-change schema.
+- Existing APIs remain compatible unless a breaking change is explicitly
+  versioned and documented.
+
+**Look out for**
+
+- Tests that seed only one company; they cannot prove tenant isolation.
+- Authorization tests that mock repositories and therefore miss an incorrect
+  database filter.
+
+## Milestone 1: Secure identity foundation
+
+### UV-SEC-001: Make identity claims truthful and stable
+
+**Goal**
+
+Remove ambiguity from the internal user record before external identities are
+linked.
+
+**Work**
+
+- Add a normalized unique username without replacing the UUID user ID.
+- Add `email_verified_at`; do not infer verification from an `Active` status.
+- Separate account status, email verification, and membership status.
+- Define safe compatibility and backfill rules for existing users.
+
+**Acceptance criteria**
+
+- UUID remains the canonical Userverse subject.
+- Existing accounts are not marked email-verified without evidence.
+- Username collisions and soft-deleted records are handled deterministically.
+- User creation remains backward-compatible or is explicitly versioned.
+
+**Look out for**
+
+- Case-sensitive uniqueness differences between SQLite, PostgreSQL, and MySQL.
+- Storing security-critical state only in mutable JSON metadata.
+- Reusing a username or email in a way that links a new person to an old
+  identity.
+
+### UV-SEC-002: Introduce per-device, revocable sessions
+
+**Goal**
+
+Replace global refresh-token versioning with explicit session and token-family
+records.
+
+**Work**
+
+- Create a session per successful login with idle and absolute expiry.
+- Issue random refresh tokens, store only hashes, and rotate on every refresh.
+- Detect reuse of an already-rotated refresh token and revoke the entire token
+  family.
+- Support listing and revoking individual sessions or all sessions for a user.
+- Revoke relevant sessions after password reset, account closure, or a high-risk
+  security event.
+
+**Acceptance criteria**
+
+- Signing in on one device does not silently revoke another device.
+- Refresh-token replay revokes the affected family and creates a security
+  event.
+- Raw refresh tokens never appear in the database, logs, traces, or audit data.
+- Concurrent refresh requests have deterministic behavior.
+
+**Look out for**
+
+- Race conditions that allow the same refresh token to rotate twice.
+- Comparing token hashes without constant-time comparison where applicable.
+- Keeping access valid after the underlying user is suspended or closed.
+
+### UV-SEC-003: Define access-token and signing-key policy
+
+**Goal**
+
+Make first-party bearer-token validation explicit and safely rotatable without
+turning it into a public OAuth token service.
+
+**Work**
+
+- Decide between opaque access tokens and short-lived signed first-party JWTs.
+- If JWTs remain, require issuer, audience, token type, issued-at, expiry, and a
+  session identifier; use an asymmetric algorithm when multiple services must
+  validate tokens.
+- Define active and retiring key handling and emergency key revocation.
+- Separate password-reset and email-verification signing contexts from access
+  sessions.
+
+**Acceptance criteria**
+
+- A token intended for verification or password reset cannot authenticate an
+  API request.
+- Wrong issuer, audience, algorithm, token type, or key ID is rejected.
+- A documented rotation exercise succeeds without accepting unknown keys.
+
+**Look out for**
+
+- Algorithm confusion or trusting an algorithm selected by the token.
+- Using one symmetric secret for unrelated token purposes.
+- Publishing a JWKS endpoint unless an actual external validation use case
+  requires it.
+
+### UV-SEC-004: Consolidate authentication abuse controls
+
+**Goal**
+
+Apply consistent controls to every unauthenticated credential and recovery
+endpoint.
+
+**Work**
+
+- Apply per-account and per-network throttles to login, verification, password
+  reset, and invitation acceptance.
+- Standardize account-enumeration-resistant responses.
+- Record security events for repeated failures, refresh reuse, session
+  revocation, and identity-link changes.
+- Define secret redaction for application logs, traces, errors, and audit events.
+
+**Acceptance criteria**
+
+- Unknown and known accounts have equivalent public recovery responses.
+- Rate limits are covered by deterministic tests.
+- Sensitive values are redacted before structured logging.
+
+**Look out for**
+
+- In-memory-only rate limits behaving differently with multiple workers.
+- Logging request bodies on token, password, or linking endpoints.
+
+## Milestone 2: Authorization product
+
+### UV-AUTHZ-001: Formalize role and permission semantics
+
+**Goal**
+
+Define an authorization schema that preserves the global role catalog while
+making company context explicit.
+
+**Recommended model**
+
+- `permission`: global immutable key such as `invoice.approve`, plus display
+  metadata.
+- `role`: reusable global role template.
+- `role_permission`: permissions supplied by a role template.
+- `company_role`: roles enabled for a company.
+- A membership-to-role join table so a membership can hold multiple enabled
+  company roles.
+
+**Work**
+
+- Decide whether companies can override a global role template. Defer overrides
+  in v1 unless a concrete use case requires them.
+- Define names, keys, deletion behavior, and versioning for roles and
+  permissions.
+- Migrate the current single `association_user_company.role_id` safely.
+
+**Acceptance criteria**
+
+- Every assigned role is enabled for the same company as the membership.
+- Permission keys are stable machine identifiers and cannot be silently renamed.
+- Deleting or closing a role cannot leave an active unauthorized assignment.
+- Existing role APIs have documented compatibility behavior.
+
+**Look out for**
+
+- Assuming a globally shared role can be edited independently by each company.
+- Role-name authorization checks; use stable IDs and permission keys.
+- Soft-delete uniqueness preventing a safe recreation or causing an old record
+  to regain authority.
+
+### UV-AUTHZ-002: Add explicit membership lifecycle and multiple roles
+
+**Goal**
+
+Represent how and when a person belongs to a company rather than treating the
+association as a boolean.
+
+**Work**
+
+- Add `invited`, `active`, `suspended`, `expired`, and `removed` states.
+- Record activation, suspension, expiry, and removal timestamps and actors.
+- Support multiple roles on an active membership.
+- Define invitation acceptance and role-change rules.
+- Prevent removal of the last effective company owner through a transactional
+  invariant.
+
+**Acceptance criteria**
+
+- Only active, unexpired memberships contribute permissions.
+- Suspending or removing a membership affects new decisions immediately.
+- State transitions reject invalid paths and are audited.
+- Last-owner protection is safe under concurrent requests.
+
+**Look out for**
+
+- Trusting a role requested in an invitation without rechecking the inviter's
+  current authority when the invitation is accepted.
+- Time comparisons using local time instead of UTC.
+- Updating several authorization records without one transaction.
+
+### UV-AUTHZ-003: Implement the authorization decision service
+
+**Goal**
+
+Provide one authoritative, deny-by-default path for application authorization.
+
+**Initial interface**
+
+```http
+POST /authorization/check
+```
+
+```json
+{
+  "user_id": "52619b0b-9e97-4672-b525-611d2dfb",
+  "company_id": "69d87dc8-8dd1-4639-b0c5-bd94a5fc47a5",
+  "resource": "invoice",
+  "action": "approve"
+}
+```
+
+```json
+{
+  "allowed": true,
+  "permission": "invoice.approve",
+  "roles": ["finance_manager"],
+  "policy_version": 12,
+  "reason": "Granted by an active company role"
+}
+```
+
+**Work**
+
+- Resolve `resource.action` to a registered permission.
+- Evaluate account state, company state, membership state and expiry, enabled
+  company roles, and role permissions.
+- Return stable machine-readable reason codes as well as a human explanation.
+- Record a correlation ID and policy version.
+- Define whether the caller may check only itself or another user.
+
+**Acceptance criteria**
+
+- Missing data and unexpected states deny access.
+- Company A roles never authorize a company B request.
+- The response explains which current role granted access without exposing
+  unrelated membership data.
+- Authorization logic is implemented in one domain service and reused by route
+  guards.
+
+**Look out for**
+
+- Letting the request body choose an unrestricted `user_id` or `company_id`.
+- Returning `allowed=true` when a dependency fails or times out.
+- Treating a platform superuser as an undocumented unconditional bypass.
+
+### UV-AUTHZ-004: Add batch checks and decision-aware SDK types
+
+**Goal**
+
+Avoid N+1 authorization calls without weakening the decision model.
+
+**Work**
+
+- Add a bounded batch-check endpoint.
+- Preserve input order and return a decision for every item.
+- Set request and item-count limits.
+- Add typed Python models and error semantics suitable for an SDK.
+
+**Acceptance criteria**
+
+- Batch and individual checks produce identical decisions.
+- A malformed item does not accidentally grant or obscure another decision.
+- Limits prevent unbounded database work.
+
+**Look out for**
+
+- Partial failure behavior that applications interpret as allowed.
+- Loading every role or permission in a company for each item.
+
+### UV-AUTHZ-005: Enforce repository-level tenant boundaries
+
+**Goal**
+
+Make it difficult for new routes to omit company isolation accidentally.
+
+**Work**
+
+- Introduce tenant-aware repository query helpers.
+- Require an explicit company context for company-owned data access.
+- Add route/service authorization helpers that call the decision service.
+- Add cross-tenant tests for reads, writes, pagination, filters, and soft-deleted
+  records.
+
+**Acceptance criteria**
+
+- Company-owned repositories cannot perform an unscoped list or mutation by
+  default.
+- Negative tenant tests cover every company route.
+- Pagination totals do not leak records from another tenant.
+
+**Look out for**
+
+- Fetching a record globally by ID and checking its company only after mutation.
+- Search, count, export, and error messages leaking cross-company existence.
+
+### UV-AUTHZ-006: Add authorization audit and access review
+
+**Goal**
+
+Make access changes and effective access explainable over time.
+
+**Work**
+
+- Create append-only events for membership, role, permission, and privileged
+  administrative changes.
+- Add queries for "why does this user have access?" and "who has this
+  permission?"
+- Add an access-review export showing active, suspended, expiring, and privileged
+  memberships.
+- Define audit retention and redaction policies.
+
+**Acceptance criteria**
+
+- Every privilege-changing transaction creates its audit event atomically.
+- Audit events capture actor, subject, company, before/after identifiers,
+  reason, timestamp, and request ID.
+- Audit output contains no passwords, bearer tokens, invitation tokens, or
+  external raw identity tokens.
+
+**Look out for**
+
+- Writing audit events after commit and losing them on a process failure.
+- Storing excessive PII or mutable display values as the only identifiers.
+- Claiming an audit table is tamper-proof without an actual integrity control.
+
+## Milestone 3: Bring-your-own identity
+
+### UV-IDP-001: Add a trusted issuer registry
+
+**Goal**
+
+Explicitly configure which external identity tokens Userverse will accept.
+
+**Work**
+
+- Store an exact issuer, allowed audiences, allowed algorithms, fixed discovery
+  or JWKS location, activation state, and ownership metadata.
+- Begin with platform-approved environment-level issuers. Defer company
+  self-service issuer registration.
+- Define cache, rotation, outage, and emergency-disable behavior.
+
+**Acceptance criteria**
+
+- Unregistered issuers and audiences are rejected.
+- Issuer comparison is exact after one documented normalization step.
+- Disabling an issuer prevents new authentication immediately.
+
+**Look out for**
+
+- Letting arbitrary company-provided URLs trigger server-side HTTP requests.
+- SSRF through discovery, redirects, DNS rebinding, or private-network JWKS URLs.
+- Using a key from one issuer to validate a token claiming another issuer.
+
+### UV-IDP-002: Implement strict inbound JWT validation
+
+**Goal**
+
+Authenticate external subjects without issuing replacement OAuth tokens.
+
+**Work**
+
+- Validate signature, fixed algorithm allow-list, issuer, audience, expiry,
+  not-before, issued-at, and required subject.
+- Support controlled clock skew and bounded JWKS caching.
+- Refresh keys safely on an unknown `kid` without fetching on every bad token.
+- Return a provider-neutral external principal containing the trusted issuer and
+  subject.
+
+**Acceptance criteria**
+
+- Tokens with `alg=none`, wrong algorithms, issuer, audience, or key are
+  rejected.
+- Key rotation succeeds while unknown-key abuse remains rate-limited.
+- Raw tokens and full claim sets are not logged.
+
+**Look out for**
+
+- Accepting an audience merely because it appears in an unvalidated claim.
+- Unbounded cache entries or network requests driven by attacker-controlled
+  `kid` values.
+- Treating a valid token as authorization for every Userverse company.
+
+### UV-IDP-003: Add explicit external identity linking
+
+**Goal**
+
+Map a validated `(issuer, subject)` to one stable Userverse user safely.
+
+**Work**
+
+- Add an `identity_link` table with a unique `(issuer_id, subject)` constraint.
+- Store provider display/email claims only as non-authoritative observations.
+- Support linking through an already-authenticated account or administrator
+  workflow.
+- Support unlinking with safeguards against locking out the user.
+- Audit every link and unlink operation.
+
+**Acceptance criteria**
+
+- Matching email alone never creates or changes a link.
+- One external identity cannot be linked to multiple active Userverse users.
+- Provider email changes do not change the Userverse user ID.
+- Linking requires proof of control or explicit authorized administration.
+
+**Look out for**
+
+- Account takeover through auto-linking, recycled email addresses, or unverified
+  email claims.
+- Deleting and recreating links in a way that erases security history.
+- Allowing the last usable authentication method to be removed accidentally.
+
+### UV-IDP-004: Integrate external principals with authorization
+
+**Goal**
+
+Allow selected Userverse APIs to authenticate a linked external subject and
+authorize it using current Userverse data.
+
+**Work**
+
+- Add a principal dependency that distinguishes first-party sessions, external
+  identities, service credentials, and superusers.
+- Map the external principal through `identity_link` before membership lookup.
+- Keep authentication method and authorization result visible in request
+  context and audit events.
+- Roll out to read-only endpoints before privileged mutations.
+
+**Acceptance criteria**
+
+- An external token grants no access without an active identity link and
+  company membership.
+- Role claims from the external token do not override Userverse permissions.
+- Existing first-party authentication remains distinguishable and compatible.
+
+**Look out for**
+
+- Choosing an authentication path based on an unverified token header or claim.
+- Ambiguous fallback behavior where a failed external token is retried as a
+  first-party token.
+
+## Milestone 4: Adoption and operations
+
+### UV-DX-001: Publish a FastAPI authorization package
+
+**Goal**
+
+Make the secure path easier than duplicating authorization logic in applications.
+
+**Work**
+
+- Provide typed clients for individual and batch decisions.
+- Provide FastAPI dependencies such as `require_permission("invoice.approve")`.
+- Define timeout behavior as deny-by-default for protected operations.
+- Propagate correlation IDs without propagating credentials.
+
+**Acceptance criteria**
+
+- An example application can protect a route with a small, documented
+  integration.
+- Errors distinguish unauthenticated, unauthorized, unavailable, and invalid
+  requests without granting on failure.
+
+**Look out for**
+
+- SDK-side caching extending access after a membership is revoked.
+- Framework helpers trusting a tenant ID directly from user-controlled input.
+
+### UV-DX-002: Add a transactional outbox and signed webhooks
+
+**Goal**
+
+Let applications react reliably to identity and authorization changes.
+
+**Work**
+
+- Write an outbox event in the same transaction as each domain change.
+- Deliver signed, versioned webhook envelopes with retry and replay protection.
+- Include stable identifiers and event versions, not secrets or unnecessary PII.
+- Provide endpoint disablement and secret rotation.
+
+**Acceptance criteria**
+
+- Domain changes cannot commit without their required outbox event.
+- Duplicate delivery is expected and documented; consumers can deduplicate by
+  event ID.
+- Signatures cover timestamp and raw body and reject stale replays.
+
+**Look out for**
+
+- Assuming exactly-once network delivery.
+- Webhook URLs reaching private infrastructure without SSRF controls.
+- Retrying permanent `4xx` failures forever.
+
+### UV-DX-003: Create reference applications and integration guides
+
+**Goal**
+
+Prove the provider-neutral story with realistic applications.
+
+**Work**
+
+- Build one B2B FastAPI example with two companies and negative tenant tests.
+- Demonstrate two upstream identity providers mapping to the same Userverse user.
+- Document invitations, suspension, role changes, permission checks, identity
+  linking, and offboarding.
+- Publish migration guidance from application-owned role tables.
+
+**Acceptance criteria**
+
+- A developer can run the example locally from a clean checkout.
+- The example visibly denies cross-company access and revoked membership.
+- No example bypasses the public SDK by querying authorization tables directly.
+
+### UV-DX-004: Add access-review and administration workflows
+
+**Goal**
+
+Give company administrators practical, safe self-service workflows.
+
+**Work**
+
+- Provide APIs for membership review, expiring access, privileged roles, and
+  identity links.
+- Add bulk operations with preview, per-item results, and audit reasons.
+- Consider an embeddable UI only after the APIs and authorization rules are
+  stable.
+
+**Acceptance criteria**
+
+- Company administrators can manage only their own company.
+- Destructive bulk changes require confirmation and are recoverable where
+  practical.
+- Every administrative change is attributable and auditable.
+
+**Look out for**
+
+- Bulk requests bypassing the same invariant checks used by single-item APIs.
+- Exports exposing users from another company or unnecessary identity-provider
+  claims.
+
+## Cross-cutting risks to watch
+
+### Tenant isolation
+
+- Never accept a company ID as sufficient proof of company access.
+- Scope reads, counts, updates, deletes, exports, and error details.
+- Test with at least two companies and overlapping role names in every suite.
+- Prefer database queries that include the company predicate over fetch-then-check
+  logic.
+
+### Authorization freshness
+
+- Do not treat role or permission claims in a long-lived token as current.
+- Keep access-token lifetimes short and evaluate sensitive authorization from
+  Userverse state.
+- If decisions are cached, include membership/policy versions and invalidate on
+  changes.
+
+### Identity linking
+
+- Use `(issuer, subject)` as the external key.
+- Email is a display/contact attribute, not account-linking proof.
+- Preserve historical link events even after unlinking.
+
+### Role-model evolution
+
+- The current global role catalog means a role definition may be shared by
+  multiple companies. Confirm that every role mutation has the intended global
+  effect.
+- Do not add permissions until template-versus-company ownership is settled.
+- Use permission keys in code; display names may change.
+
+### Database portability and concurrency
+
+- Exercise uniqueness, case normalization, transaction isolation, and locking
+  on each supported production database.
+- Protect last-owner, refresh rotation, invitation acceptance, and role-change
+  invariants transactionally.
+- Avoid JSON metadata for authoritative relationships that need constraints or
+  indexed queries.
+
+### Observability and privacy
+
+- Record reason codes, timing, actor, company, and request ID.
+- Never record passwords, reset codes, invitation tokens, bearer tokens, client
+  secrets, or full external claim sets.
+- Define audit retention, user-data deletion, and legal export behavior before
+  promising compliance.
+
+### Availability and fail-safe behavior
+
+- Authorization-check failures must not become implicit allows.
+- Define which low-risk reads may use a bounded stale cache and which operations
+  must fail closed.
+- Monitor latency, deny rates, issuer/JWKS failures, refresh reuse, and
+  cross-tenant denial events.
+
+## Decision gates
+
+### Gate 1: Secure foundation
+
+Proceed to the authorization product only when session replay tests, truthful
+identity migration, and the cross-company regression matrix pass.
+
+### Gate 2: Useful authorization
+
+Proceed to external identity integration only when a reference application can
+use the decision API for real permissions, explain decisions, revoke membership
+immediately, and pass negative tenant tests.
+
+### Gate 3: Provider neutrality
+
+Claim provider neutrality only after two independent upstream issuers can map to
+the same stable Userverse identity without email auto-linking or provider role
+claims becoming authoritative.
+
+### Gate 4: Broader standards work
+
+Reconsider SCIM, SAML, or OAuth/OIDC provider functionality only when multiple
+real customers require it and the security and operational ownership is funded.
+
+## Success measures
+
+- Zero known cross-company authorization paths.
+- Membership suspension is reflected in new authorization decisions immediately.
+- Every privilege change has an associated audit event.
+- A new FastAPI application can protect its first company-scoped action in less
+  than one hour using documented examples.
+- Applications can change upstream IdP without changing Userverse user IDs or
+  company memberships.
+- Authorization check latency and availability meet a defined service-level
+  objective before the decision API is placed on critical request paths.
+
+## Common definition of done for tickets
+
+A roadmap ticket is complete only when:
+
+- Behavior and security invariants are documented.
+- Unit, integration, negative tenant, and migration tests are included where
+  applicable.
+- Audit and observability behavior is defined.
+- Existing API compatibility has been checked.
+- No security-sensitive value is exposed in logs or response errors.
+- Documentation and a rollback or disablement path are included.
+
+## Reference landscape
+
+These projects demonstrate that organization/RBAC functionality alone is not a
+distinct market position:
+
+- [Auth0 RBAC](https://auth0.com/docs/manage-users/access-control/rbac)
+- [Clerk organization roles and permissions](https://clerk.com/docs/guides/organizations/control-access/roles-and-permissions)
+- [WorkOS RBAC](https://workos.com/docs/rbac/integration)
+- [Logto organization management](https://docs.logto.io/organizations/organization-management)
+- [ZITADEL organizations](https://zitadel.com/docs/guides/manage/console/organizations-overview)
+
+OpenFGA is a useful comparison for a broader relationship-based authorization
+system. Userverse should remain more opinionated and simpler unless real use
+cases justify a general model:
+
+- [OpenFGA concepts](https://openfga.dev/docs/concepts)

--- a/docs/potential/provider-neutral-authorization-roadmap.md
+++ b/docs/potential/provider-neutral-authorization-roadmap.md
@@ -318,6 +318,12 @@ making company context explicit.
   permissions but never imply company membership.
 - `company_role`: global roles enabled for a company. A company membership still
   holds one enabled role in the initial implementation.
+- Deterministic protected global permissions authorize Userverse's built-in
+  company APIs in the service layer. Owner, Administrator, and Viewer receive
+  explicit default baselines; superusers remain the bootstrap bypass.
+- Core company authorization uses the seeded global permission UUID and scope,
+  so a same-named tenant permission or direct platform role cannot grant tenant
+  access without an active company membership.
 
 **Work**
 

--- a/docs/role-permission-guide.md
+++ b/docs/role-permission-guide.md
@@ -90,6 +90,55 @@ All endpoints require a bearer access token.
 The `is_superuser` flag remains the bootstrap administration mechanism. It does
 not create an implicit role or permission assignment.
 
+## Built-in company API permissions
+
+Userverse seeds 16 protected global permissions for its own company-management
+APIs. Their UUIDs are deterministic and their names are stable machine keys.
+They are attached to the built-in roles as follows:
+
+| Global system permission | Protected API | Owner | Administrator | Viewer |
+| --- | --- | :---: | :---: | :---: |
+| `company.read` | `GET /company` | yes | yes | yes |
+| `company.update` | `PATCH /company/{company_id}` | yes | yes | no |
+| `company.delete` | `DELETE /company/{company_id}` | yes | no | no |
+| `company.members.read` | `GET /company/{company_id}/users` | yes | yes | yes |
+| `company.members.add` | `POST /company/{company_id}/users` | yes | yes | no |
+| `company.members.role.update` | `PATCH /company/{company_id}/user/{user_id}` | yes | yes | no |
+| `company.members.remove` | `DELETE /company/{company_id}/user/{user_id}` | yes | yes | no |
+| `company.roles.read` | `GET /company/{company_id}/roles` | yes | yes | no |
+| `company.roles.assign` | `POST /company/{company_id}/roles/{role_id}` | yes | yes | no |
+| `company.roles.unassign` | `DELETE /company/{company_id}/roles/{role_id}` | yes | yes | no |
+| `company.permissions.read` | Company permission lists and effective role-permission reads | yes | yes | no |
+| `company.permissions.create` | `POST /company/{company_id}/permissions` | yes | yes | no |
+| `company.permissions.update` | `PATCH /company/{company_id}/permissions/{permission_id}` | yes | yes | no |
+| `company.permissions.delete` | `DELETE /company/{company_id}/permissions/{permission_id}` | yes | yes | no |
+| `company.permissions.assign` | Attach a company permission to a role | yes | yes | no |
+| `company.permissions.unassign` | Remove a company permission from a role | yes | yes | no |
+
+Every protected service operation checks the exact seeded global permission
+identity. A non-superuser must have an active membership whose role is still
+enabled for that company and whose global baseline contains that permission.
+A company permission with the same display name, such as a tenant-created
+`company.delete`, never authorizes a built-in Userverse API.
+
+Superusers bypass these company membership and permission checks. Direct
+platform roles do not: even a direct platform `Owner` assignment cannot read or
+change a company without company membership.
+
+The seeded permissions are system records:
+
+- Their names and UUIDs cannot be changed, and deleting them returns `409`.
+- A superuser may update their descriptions.
+- A superuser may attach or remove the real system permission from global roles.
+  Changes take effect on the next request.
+- Default links are added when built-in roles are first created or by the data
+  migration. A deliberately removed link is not silently restored later.
+
+A custom global role can authorize a built-in tenant API. A superuser must
+attach the actual seeded system permission to that role, enable the role for the
+company, and assign it through an active company membership. Matching the name
+with a new permission is insufficient.
+
 The examples below assume:
 
 ```bash
@@ -345,5 +394,6 @@ and return `404`.
 - Changing a global role permission propagates immediately to every company and
   platform user using that role.
 - Company additions are isolated: changes in company A do not change company B.
-- Permission introspection exposes effective permissions but does not yet
-  replace existing route authorization with permission-key checks.
+- Userverse's built-in company-management APIs enforce the protected system
+  permissions in their service layer. Tenant application permissions remain
+  available for application-specific authorization decisions.

--- a/docs/role-permission-guide.md
+++ b/docs/role-permission-guide.md
@@ -1,0 +1,349 @@
+# Global and Company RBAC Guide
+
+Userverse uses a hybrid role-based access control model. Roles come from one
+global catalog, while their permissions can come from two scopes:
+
+- **Global permissions** are application-wide baseline permissions attached to
+  a global role.
+- **Company permissions** belong to one company and add capabilities to a role
+  only in that company.
+- **Platform role assignments** attach global roles directly to users and grant
+  only the roles' global permissions.
+
+A platform role never creates company membership and never authorizes access to
+company data by itself.
+
+## Mental model
+
+For a role `r`, company `c`, and user `u`:
+
+```text
+global role view(r)       = global permissions on r
+company role view(c, r)   = global permissions on r
+                            + company c permissions attached to r
+platform permissions(u)   = global permissions from roles assigned directly to u
+```
+
+Company permissions are additive. A company cannot remove, replace, or deny a
+global permission inherited from a role. Tenant overrides and deny rules are not
+part of this implementation.
+
+For example:
+
+```text
+Manager global baseline: app.dashboard.view
+Company A addition:      invoice.approve
+Company B addition:      report.publish
+
+Manager in company A -> app.dashboard.view + invoice.approve
+Manager in company B -> app.dashboard.view + report.publish
+Platform Manager      -> app.dashboard.view only
+```
+
+## Records and identity
+
+| Record | Scope | Purpose |
+| --- | --- | --- |
+| `role` | Global | Reusable role catalog, such as `Manager` |
+| `global_permission` | Global | Application capability, such as `app.dashboard.view` |
+| `role_global_permission` | Global | Adds a mandatory baseline permission to a role |
+| `company_role` | Company | Makes a global role available in one company |
+| `company_permission` | Company | Tenant-owned capability, such as `invoice.approve` |
+| `company_role_permission` | Company | Adds a tenant permission to an enabled company role |
+| `association_user_company` | Company | Gives a member one role in a company |
+| `user_role` | Platform | Assigns a global role directly to a user |
+
+Permission names are trimmed and stored verbatim. Global names are unique
+globally; company names are unique inside their company. A global permission and
+a company permission may have the same name, but they are different permissions.
+Use the permission UUID together with `scope` and `company_id` as its identity.
+
+Permission responses use this shape:
+
+```json
+{
+  "id": "3a6f7287-9aa5-4f89-a61e-0ad7ae1f8210",
+  "name": "invoice.approve",
+  "description": "Approve an invoice",
+  "scope": "company",
+  "company_id": "caefbf3a-0663-4997-919f-cd3b2f067d28"
+}
+```
+
+For a global permission, `scope` is `global` and `company_id` is `null`.
+
+## Authentication and management rights
+
+All endpoints require a bearer access token.
+
+| Operation | Required actor |
+| --- | --- |
+| Create, update, or delete global roles | Superuser |
+| Create, update, or delete global permissions | Superuser |
+| Attach or remove global permissions from roles | Superuser |
+| Assign or remove direct platform roles | Superuser |
+| Manage a company's permissions | Company Owner, Administrator, or superuser |
+| Attach or remove company permissions from roles | Company Owner, Administrator, or superuser |
+| Enable or disable an existing role for a company | Company Owner or Administrator |
+| Read the current user's platform permissions | Authenticated user |
+
+The `is_superuser` flag remains the bootstrap administration mechanism. It does
+not create an implicit role or permission assignment.
+
+The examples below assume:
+
+```bash
+BASE_URL=http://127.0.0.1:8500/userverse
+SUPERUSER_TOKEN=replace-with-superuser-access-token
+COMPANY_ADMIN_TOKEN=replace-with-owner-or-administrator-access-token
+USER_TOKEN=replace-with-user-access-token
+COMPANY_ID=replace-with-company-uuid
+USER_ID=replace-with-user-uuid
+```
+
+## Global role and permission workflow
+
+### 1. Create a global role
+
+```bash
+curl -X POST "$BASE_URL/roles" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Manager",
+    "description": "Application manager"
+  }'
+```
+
+Save `data.id` from the response as `ROLE_ID`.
+
+### 2. Create a global application permission
+
+```bash
+curl -X POST "$BASE_URL/permissions" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "app.dashboard.view",
+    "description": "View the application dashboard"
+  }'
+```
+
+Save `data.id` as `GLOBAL_PERMISSION_ID`.
+
+### 3. Attach the global permission to the role
+
+```bash
+curl -X POST \
+  "$BASE_URL/roles/$ROLE_ID/permissions/$GLOBAL_PERMISSION_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+```
+
+Every use of this role now inherits the permission. Companies cannot remove it
+from their local view of the role.
+
+### 4. Inspect global permissions on a role
+
+```bash
+curl "$BASE_URL/roles/$ROLE_ID/permissions" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+```
+
+`GET /roles` also returns each role with structured global permission objects in
+its `permissions` list. It does not include any company's additions.
+
+### 5. Update, detach, or delete
+
+```bash
+# Rename or change the description
+curl -X PATCH "$BASE_URL/permissions/$GLOBAL_PERMISSION_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"description":"View the main application dashboard"}'
+
+# Remove the permission from this role only
+curl -X DELETE \
+  "$BASE_URL/roles/$ROLE_ID/permissions/$GLOBAL_PERMISSION_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+
+# Hard-delete the permission and all of its role links
+curl -X DELETE "$BASE_URL/permissions/$GLOBAL_PERMISSION_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+```
+
+Deleting a permission never deletes or modifies the role itself.
+
+## Company role and permission workflow
+
+Company permissions can be attached only to roles enabled for the same company.
+Composite database foreign keys enforce this tenant boundary.
+
+### 1. Enable an existing global role for the company
+
+```bash
+curl -X POST "$BASE_URL/company/$COMPANY_ID/roles/$ROLE_ID" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+```
+
+The returned role initially contains its global baseline permissions.
+
+### 2. Create a company permission
+
+```bash
+curl -X POST "$BASE_URL/company/$COMPANY_ID/permissions" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "invoice.approve",
+    "description": "Approve invoices in this company"
+  }'
+```
+
+Save `data.id` as `COMPANY_PERMISSION_ID`.
+
+### 3. Attach the company permission to the enabled role
+
+```bash
+curl -X POST \
+  "$BASE_URL/company/$COMPANY_ID/roles/$ROLE_ID/permissions/$COMPANY_PERMISSION_ID" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+```
+
+The returned `permissions` list is the effective company view: the role's global
+baseline plus this company's additions.
+
+### 4. Inspect company permissions and effective role permissions
+
+```bash
+# Permissions defined by the company
+curl "$BASE_URL/company/$COMPANY_ID/permissions?limit=10&page=1" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+
+# Global baseline plus this company's additions
+curl "$BASE_URL/company/$COMPANY_ID/roles/$ROLE_ID/permissions" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+
+# All enabled roles, each with effective permissions
+curl "$BASE_URL/company/$COMPANY_ID/roles?limit=10&page=1" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+```
+
+### 5. Assign the role to a company member
+
+Company membership remains single-role. The `role` field is the global role
+name and that role must already be enabled for the company.
+
+```bash
+curl -X POST "$BASE_URL/company/$COMPANY_ID/users" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "manager@example.com",
+    "role": "Manager"
+  }'
+```
+
+Company-user and current-user company responses include the role's structured,
+effective permission list.
+
+### 6. Remove or delete company permissions
+
+```bash
+# Remove the link from one company role
+curl -X DELETE \
+  "$BASE_URL/company/$COMPANY_ID/roles/$ROLE_ID/permissions/$COMPANY_PERMISSION_ID" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+
+# Hard-delete the permission and all role links in this company
+curl -X DELETE \
+  "$BASE_URL/company/$COMPANY_ID/permissions/$COMPANY_PERMISSION_ID" \
+  -H "Authorization: Bearer $COMPANY_ADMIN_TOKEN"
+```
+
+Unassigning a role from a company also removes that company's permission links
+for the role. It does not remove the role from the global catalog or affect
+another company.
+
+## Direct platform roles
+
+Direct platform assignments are useful for application-level access that is not
+tied to a company. A user may hold multiple direct roles.
+
+```bash
+# Assign a direct role
+curl -X POST "$BASE_URL/users/$USER_ID/roles/$ROLE_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+
+# List direct roles and their global permissions
+curl "$BASE_URL/users/$USER_ID/roles" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+
+# Remove only the direct assignment
+curl -X DELETE "$BASE_URL/users/$USER_ID/roles/$ROLE_ID" \
+  -H "Authorization: Bearer $SUPERUSER_TOKEN"
+```
+
+The authenticated user can inspect the deduplicated union of global permissions
+from their direct platform roles:
+
+```bash
+curl "$BASE_URL/user/permissions" \
+  -H "Authorization: Bearer $USER_TOKEN"
+```
+
+Company permissions never appear in this response. A direct `Manager` role does
+not make the user a member of any company and cannot be used to read or mutate
+tenant resources.
+
+## Listing and filtering permissions
+
+Global and company permission lists are paginated and support partial `name` and
+`description` filters:
+
+```text
+GET /permissions?name=dashboard&description=view&limit=20&page=1
+GET /company/{company_id}/permissions?name=invoice&limit=20&page=1
+```
+
+The response has this shape:
+
+```json
+{
+  "message": "Permissions retrieved successfully.",
+  "data": {
+    "records": [],
+    "pagination": {
+      "total_records": 0,
+      "limit": 20,
+      "current_page": 1,
+      "total_pages": 0
+    }
+  }
+}
+```
+
+## Failure behavior
+
+| Status | Meaning |
+| --- | --- |
+| `403` | The authenticated actor cannot manage the requested scope |
+| `404` | The permission, role, company, assignment, or scoped resource does not exist |
+| `409` | A permission name or assignment already exists in that scope |
+| `422` | The request is invalid, such as a blank name or empty update |
+
+Cross-company permission identifiers deliberately behave as missing resources
+and return `404`.
+
+## Lifecycle and safety rules
+
+- Permission deletion is physical, so its name can be reused immediately.
+- Removing a permission deletes its role links but leaves roles unchanged.
+- Removing a platform role deletes only the `user_role` link.
+- A global role cannot be deleted while used by an active company membership or
+  a platform user.
+- Inactive or deleted users cannot receive new platform role assignments.
+- Changing a global role permission propagates immediately to every company and
+  platform user using that role.
+- Company additions are isolated: changes in company A do not change company B.
+- Permission introspection exposes effective permissions but does not yet
+  replace existing route authorization with permission-key checks.

--- a/docs/superuser-administration.md
+++ b/docs/superuser-administration.md
@@ -1,0 +1,165 @@
+# Superuser Bootstrap and Administration
+
+Userverse treats `is_superuser` as a platform recovery and bootstrap authority.
+It is deliberately separate from global roles, platform-role assignments, and
+company membership.
+
+This release implements only the one-time offline bootstrap command. Superuser
+promotion APIs, step-up authentication, demotion, and access-review endpoints
+are documented below as follow-up work and are not currently available.
+
+## Security model
+
+The bootstrap command:
+
+- must be run from a trusted host, application container, or Kubernetes job
+  that already has database access;
+- promotes an existing user and never creates an account;
+- never accepts a password, access token, or refresh token;
+- requires the user to be active, verified, and not soft-deleted;
+- serializes attempts through the singleton `superuser_bootstrap_control` row;
+- refuses to run if any superuser already exists;
+- is idempotent only for the original, still-superuser account;
+- records `superuser_bootstrapped` in `privileged_access_event` in the same
+  transaction as the promotion; and
+- increments the target's refresh-token version, invalidating all existing
+  access and refresh tokens.
+
+Do not add automatic startup promotion, a `SUPERUSER_EMAIL` environment
+variable, a public "first user" endpoint, or a data migration containing an
+administrator email. Those mechanisms can silently grant platform-root access
+in the wrong environment.
+
+## Bootstrap procedure
+
+### 1. Register and verify the account
+
+Create the administrator through the normal registration flow. Confirm the
+account status is `Active` before continuing. The CLI will not activate or
+verify it.
+
+### 2. Apply migrations
+
+```bash
+alembic upgrade head
+```
+
+The command intentionally fails if the bootstrap-control row is absent.
+
+### 3. Run interactively
+
+```bash
+userverse-admin bootstrap-superuser \
+  --email admin@example.com \
+  --reason "Initial production bootstrap"
+```
+
+The prompt displays the resolved email and UUID. Confirm only after comparing
+both values with the intended account.
+
+When running from the repository without installing the entry point:
+
+```bash
+uv run userverse-admin bootstrap-superuser \
+  --email admin@example.com \
+  --reason "Initial production bootstrap"
+```
+
+### 4. Run non-interactively
+
+Automation must supply the exact UUID obtained from a separate, trusted account
+lookup:
+
+```bash
+userverse-admin bootstrap-superuser \
+  --email admin@example.com \
+  --reason "Initial production bootstrap" \
+  --confirm-user-id 11111111-2222-3333-4444-555555555555
+```
+
+An email/UUID mismatch aborts without changing either account. Do not derive the
+confirmation UUID from untrusted job input in the same command.
+
+### 5. Sign in again
+
+All sessions belonging to the promoted user are invalidated. The user must sign
+in again before accessing global role, permission, or platform administration
+APIs.
+
+### 6. Verify the audit record
+
+Confirm that one `privileged_access_event` exists with:
+
+```text
+action: superuser_bootstrapped
+source: operator_cli
+target_user_id: <expected UUID>
+previous_superuser: false
+resulting_superuser: true
+```
+
+The reason is stored, but credentials and tokens are never recorded.
+
+## Idempotency and failure behavior
+
+- Repeating the command for the original user succeeds without creating a
+  second event or invalidating sessions again.
+- Repeating it for a different user fails.
+- If the original user is no longer a superuser, the command fails instead of
+  silently restoring access.
+- If any superuser predates the control record, bootstrap fails and requires an
+  operator investigation.
+- The command does not provide a disaster-recovery bypass. Database recovery
+  procedures should remain restricted to trusted infrastructure operators.
+
+## Next milestone: superuser administration APIs
+
+The next implementation should add:
+
+```text
+POST  /user/reauthenticate
+GET   /admin/superusers
+PATCH /admin/users/{user_id}/superuser
+```
+
+The `PATCH` request should be idempotent:
+
+```json
+{
+  "enabled": true,
+  "reason": "Secondary break-glass administrator"
+}
+```
+
+Required controls:
+
+1. Load the actor from the database and require an active superuser. Platform
+   roles and permissions must not authorize this operation.
+2. Require recent password reauthentication through a short-lived,
+   single-purpose step-up token. Require MFA once supported.
+3. Require the target to be active, verified, and not deleted.
+4. Lock the singleton control row for every promotion or demotion.
+5. Prevent demotion, suspension, deactivation, or deletion of the final active
+   superuser, including through `DELETE /user/me`.
+6. Increment the target's refresh-token version after every privilege change.
+7. Write the before/after audit event atomically with the user update.
+8. Notify the target and security contacts after commit, preferably through a
+   transactional outbox.
+9. Keep `is_superuser` out of ordinary profile updates and tenant member
+   management APIs.
+
+Until that milestone is implemented, the bootstrap CLI cannot and must not be
+used to promote a second user. Production environments that require two
+break-glass administrators should complete the administration API milestone
+before relying on this bootstrap flow for general operations.
+
+## Required follow-up tests
+
+- Promotion and demotion require a current superuser and recent reauthentication.
+- Company permissions and direct platform roles cannot grant superuser access.
+- Promotion and demotion invalidate all target sessions immediately.
+- Concurrent changes cannot remove the final active superuser.
+- Self-deletion and suspension respect the final-superuser invariant.
+- Every privilege change creates exactly one atomic audit event.
+- Failed audit writes roll back privilege changes.
+- Audit and application logs contain no passwords or tokens.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,7 +22,7 @@ It then runs:
 pytest -v --cov=app \
   --cov-report=term-missing \
   --cov-report=xml:coverage_reports/coverage.xml \
-  --cov-fail-under=96
+  --cov-fail-under=100
 ```
 
 For local development, prefer focused runs:
@@ -43,6 +43,9 @@ uv run --no-cache pytest tests/utils
 ```
 
 By default, the HTTP suite uses a temporary SQLite database and patches email dispatch so tests do not perform network SMTP calls.
+
+The configured statement-coverage gate is 100%. New executable application
+paths must therefore include a focused test in the same change.
 
 If you need to seed or validate a non-temporary environment, pass `--http-env-file`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - Adding Users to Organizations: add_users_to_organizations.md
       - Managing Roles: manage_roles.md
       - Global and Company RBAC: role-permission-guide.md
+      - Superuser Administration: superuser-administration.md
       - Updating Organization Details: update_organization_details.md
   - User-Organization Linking:
       - Inviting Users: invite_users.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,4 +19,6 @@ nav:
   - Reports and Analytics:
       - User Activity Reports: user_activity_reports.md
       - Organization Reports: organization_reports.md
+  - Potential Roadmaps:
+      - Provider-Neutral B2B Authorization: potential/provider-neutral-authorization-roadmap.md
   - FAQ: faq.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Settings Guide:
       - Adding Users to Organizations: add_users_to_organizations.md
       - Managing Roles: manage_roles.md
+      - Global and Company RBAC: role-permission-guide.md
       - Updating Organization Details: update_organization_details.md
   - User-Organization Linking:
       - Inviting Users: invite_users.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,16 @@ dependencies = [
     "mysqlclient>=2.2.8",
 ]
 
+[project.scripts]
+userverse-admin = "app.cli.admin:main"
+
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["app*"]
+
 [project.urls]
 Repository = "https://github.com/SoftwareVerse/userverse.git"
 Documentation = "https://userverse.softwareverse.co.za/docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 96
+fail_under = 100
 show_missing = true
 
 

--- a/scripts/run_http_tests.sh
+++ b/scripts/run_http_tests.sh
@@ -27,7 +27,7 @@ echo "Generating Coverage Report Summary:"
 uv run pytest -v --cov=app \
     --cov-report=term-missing \
     --cov-report=xml:"$COVERAGE_DIR/coverage.xml" \
-    --cov-fail-under=96
+    --cov-fail-under=100
 
 
 echo "========================================="

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ The `scripts/run_http_tests.sh` script sets these values and runs pytest with co
 ./scripts/run_http_tests.sh
 ```
 
-Coverage output is written to `coverage_reports/coverage.xml`, and CI enforces a `96%` coverage threshold.
+Coverage output is written to `coverage_reports/coverage.xml`, and CI enforces a `100%` statement-coverage threshold.
 
 ## Directory Structure
 

--- a/tests/api/http/c_company_roles/test_h_global_role_management.py
+++ b/tests/api/http/c_company_roles/test_h_global_role_management.py
@@ -10,11 +10,12 @@ from app.models.company.response_messages import (
 pytestmark = pytest.mark.anyio
 
 
-def _role_payload() -> dict:
+def _role_payload(test_global_rbac_data: dict) -> dict:
     suffix = uuid4().hex
+    role = test_global_rbac_data["roles"]["managed"]
     return {
-        "name": f"Global Role {suffix}",
-        "description": f"Global role description {suffix}",
+        "name": f"{role['name']} {suffix}",
+        "description": f"{role['description']} {suffix}",
     }
 
 
@@ -29,9 +30,9 @@ async def _create_global_role(client, token: str, payload: dict) -> dict:
 
 
 async def test_superuser_can_manage_global_roles_and_bulk_assign(
-    client, login_token_superuser, seed_companies
+    client, login_token_superuser, seed_companies, test_global_rbac_data
 ):
-    payload = _role_payload()
+    payload = _role_payload(test_global_rbac_data)
     created = await _create_global_role(client, login_token_superuser, payload)
     assert created["permissions"] == []
     role_id = created["id"]
@@ -84,12 +85,16 @@ async def test_superuser_can_manage_global_roles_and_bulk_assign(
 
 
 async def test_company_owner_cannot_manage_global_roles(
-    client, login_token, login_token_superuser, seed_companies
+    client,
+    login_token,
+    login_token_superuser,
+    seed_companies,
+    test_global_rbac_data,
 ):
     owner_headers = {"Authorization": f"Bearer {login_token}"}
     create_response = await client.post(
         "/roles",
-        json=_role_payload(),
+        json=_role_payload(test_global_rbac_data),
         headers=owner_headers,
     )
     assert create_response.status_code == 403, create_response.text
@@ -98,7 +103,11 @@ async def test_company_owner_cannot_manage_global_roles(
         == CompanyRoleResponseMessages.ROLE_MANAGEMENT_FORBIDDEN.value
     )
 
-    created = await _create_global_role(client, login_token_superuser, _role_payload())
+    created = await _create_global_role(
+        client,
+        login_token_superuser,
+        _role_payload(test_global_rbac_data),
+    )
     assert created["permissions"] == []
     role_id = created["id"]
 
@@ -136,9 +145,17 @@ async def test_company_owner_cannot_manage_global_roles(
 
 
 async def test_owner_can_assign_and_unassign_existing_role_for_company(
-    client, login_token, login_token_superuser, seed_companies
+    client,
+    login_token,
+    login_token_superuser,
+    seed_companies,
+    test_global_rbac_data,
 ):
-    created = await _create_global_role(client, login_token_superuser, _role_payload())
+    created = await _create_global_role(
+        client,
+        login_token_superuser,
+        _role_payload(test_global_rbac_data),
+    )
     assert created["permissions"] == []
     role_id = created["id"]
     company_id = seed_companies["company_one"]
@@ -167,9 +184,18 @@ async def test_owner_can_assign_and_unassign_existing_role_for_company(
 
 
 async def test_non_manager_cannot_assign_or_unassign_company_role(
-    client, login_token, login_token_user_two, login_token_superuser, seed_companies
+    client,
+    login_token,
+    login_token_user_two,
+    login_token_superuser,
+    seed_companies,
+    test_global_rbac_data,
 ):
-    created = await _create_global_role(client, login_token_superuser, _role_payload())
+    created = await _create_global_role(
+        client,
+        login_token_superuser,
+        _role_payload(test_global_rbac_data),
+    )
     assert created["permissions"] == []
     role_id = created["id"]
     company_id = seed_companies["company_one"]

--- a/tests/api/http/c_company_roles/test_i_hybrid_permissions.py
+++ b/tests/api/http/c_company_roles/test_i_hybrid_permissions.py
@@ -1,0 +1,634 @@
+from uuid import uuid4
+
+import pytest
+
+from app.repository.database import session_manager
+from app.repository.database.tables import CompanyRole, Role, User
+
+pytestmark = pytest.mark.anyio
+
+
+def _user_id(email: str):
+    session = session_manager.session_local()
+    try:
+        return session.query(User).filter_by(email=email).one().id
+    finally:
+        session.close()
+
+
+def _role_id(company_id, name: str):
+    session = session_manager.session_local()
+    try:
+        return (
+            session.query(Role.id)
+            .join(CompanyRole, CompanyRole.role_id == Role.id)
+            .filter(
+                CompanyRole.company_id == company_id,
+                CompanyRole._closed_at.is_(None),
+                Role.name == name,
+                Role._closed_at.is_(None),
+            )
+            .scalar()
+        )
+    finally:
+        session.close()
+
+
+async def test_hybrid_global_company_and_platform_permissions(
+    client,
+    login_token,
+    login_token_user_two,
+    login_token_superuser,
+    seed_companies,
+):
+    suffix = uuid4().hex
+    super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    company_one_headers = {"Authorization": f"Bearer {login_token}"}
+    company_two_headers = {"Authorization": f"Bearer {login_token_user_two}"}
+    company_one = seed_companies["company_one"]
+    company_two = seed_companies["company_two"]
+
+    role_response = await client.post(
+        "/roles",
+        json={
+            "name": f"Hybrid Manager {suffix}",
+            "description": "Hybrid permission test role",
+        },
+        headers=super_headers,
+    )
+    assert role_response.status_code == 201, role_response.text
+    role_id = role_response.json()["data"]["id"]
+
+    global_response = await client.post(
+        "/permissions",
+        json={
+            "name": f"app.dashboard.view.{suffix}",
+            "description": "View the platform dashboard",
+        },
+        headers=super_headers,
+    )
+    assert global_response.status_code == 201, global_response.text
+    global_permission = global_response.json()["data"]
+    assert global_permission["scope"] == "global"
+    assert global_permission["company_id"] is None
+
+    forbidden_global = await client.post(
+        "/permissions",
+        json={"name": f"app.forbidden.{suffix}"},
+        headers=company_one_headers,
+    )
+    assert forbidden_global.status_code == 403
+
+    assigned_global = await client.post(
+        f"/roles/{role_id}/permissions/{global_permission['id']}",
+        headers=super_headers,
+    )
+    assert assigned_global.status_code == 201, assigned_global.text
+    assert assigned_global.json()["data"]["permissions"] == [global_permission]
+    global_role_permissions = await client.get(
+        f"/roles/{role_id}/permissions",
+        headers=super_headers,
+    )
+    assert global_role_permissions.status_code == 200
+    assert global_role_permissions.json()["data"] == [global_permission]
+    global_role_list = await client.get(
+        "/roles",
+        params={"name": f"Hybrid Manager {suffix}"},
+        headers=super_headers,
+    )
+    assert global_role_list.status_code == 200
+    assert global_role_list.json()["data"]["records"][0]["permissions"] == [
+        global_permission
+    ]
+    duplicate_global_assignment = await client.post(
+        f"/roles/{role_id}/permissions/{global_permission['id']}",
+        headers=super_headers,
+    )
+    assert duplicate_global_assignment.status_code == 409
+
+    for company_id, headers in (
+        (company_one, company_one_headers),
+        (company_two, company_two_headers),
+    ):
+        response = await client.post(
+            f"/company/{company_id}/roles/{role_id}",
+            headers=headers,
+        )
+        assert response.status_code == 201, response.text
+        assert response.json()["data"]["permissions"] == [global_permission]
+
+    company_one_permission_response = await client.post(
+        f"/company/{company_one}/permissions",
+        json={
+            "name": f"invoice.approve.{suffix}",
+            "description": "Approve invoices for company one",
+        },
+        headers=company_one_headers,
+    )
+    assert company_one_permission_response.status_code == 201
+    company_one_permission = company_one_permission_response.json()["data"]
+    assert company_one_permission["scope"] == "company"
+    assert company_one_permission["company_id"] == str(company_one)
+
+    company_two_permission_response = await client.post(
+        f"/company/{company_two}/permissions",
+        json={
+            "name": f"invoice.approve.{suffix}",
+            "description": "Same tenant-local name for company two",
+        },
+        headers=company_two_headers,
+    )
+    assert company_two_permission_response.status_code == 201
+    company_two_permission = company_two_permission_response.json()["data"]
+
+    cross_tenant = await client.post(
+        (
+            f"/company/{company_one}/roles/{role_id}/permissions/"
+            f"{company_two_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert cross_tenant.status_code == 404
+
+    local_assignment = await client.post(
+        (
+            f"/company/{company_one}/roles/{role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert local_assignment.status_code == 201, local_assignment.text
+    assert {
+        item["scope"] for item in local_assignment.json()["data"]["permissions"]
+    } == {
+        "global",
+        "company",
+    }
+    duplicate_local_assignment = await client.post(
+        (
+            f"/company/{company_one}/roles/{role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert duplicate_local_assignment.status_code == 409
+    removed_local_assignment = await client.delete(
+        (
+            f"/company/{company_one}/roles/{role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert removed_local_assignment.status_code == 200
+    assert removed_local_assignment.json()["data"]["permissions"] == [global_permission]
+    reassigned_local = await client.post(
+        (
+            f"/company/{company_one}/roles/{role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert reassigned_local.status_code == 201
+
+    owner_role_id = _role_id(company_one, "Owner")
+    owner_global_assignment = await client.post(
+        f"/roles/{owner_role_id}/permissions/{global_permission['id']}",
+        headers=super_headers,
+    )
+    assert owner_global_assignment.status_code == 201
+    owner_local_assignment = await client.post(
+        (
+            f"/company/{company_one}/roles/{owner_role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+    assert owner_local_assignment.status_code == 201
+
+    user_companies = await client.get(
+        "/user/companies?limit=10&page=1",
+        headers=company_one_headers,
+    )
+    company_record = next(
+        record
+        for record in user_companies.json()["data"]["records"]
+        if record["id"] == str(company_one)
+    )
+    assert {item["id"] for item in company_record["role"]["permissions"]} == {
+        global_permission["id"],
+        company_one_permission["id"],
+    }
+
+    company_users = await client.get(
+        f"/company/{company_one}/users?limit=10&page=1",
+        headers=company_one_headers,
+    )
+    owner_record = next(
+        record
+        for record in company_users.json()["data"]["records"]
+        if record["email"] == "user.one@email.com"
+    )
+    assert {item["id"] for item in owner_record["role"]["permissions"]} == {
+        global_permission["id"],
+        company_one_permission["id"],
+    }
+
+    await client.delete(
+        f"/roles/{owner_role_id}/permissions/{global_permission['id']}",
+        headers=super_headers,
+    )
+    await client.delete(
+        (
+            f"/company/{company_one}/roles/{owner_role_id}/permissions/"
+            f"{company_one_permission['id']}"
+        ),
+        headers=company_one_headers,
+    )
+
+    company_two_effective = await client.get(
+        f"/company/{company_two}/roles/{role_id}/permissions",
+        headers=company_two_headers,
+    )
+    assert company_two_effective.status_code == 200
+    assert company_two_effective.json()["data"] == [global_permission]
+
+    user_id = _user_id("user.one@email.com")
+    platform_assignment = await client.post(
+        f"/users/{user_id}/roles/{role_id}",
+        headers=super_headers,
+    )
+    assert platform_assignment.status_code == 201, platform_assignment.text
+    assert platform_assignment.json()["data"][0]["permissions"] == [global_permission]
+    platform_roles = await client.get(
+        f"/users/{user_id}/roles",
+        headers=super_headers,
+    )
+    assert platform_roles.status_code == 200
+    assert platform_roles.json()["data"] == platform_assignment.json()["data"]
+    duplicate_platform_assignment = await client.post(
+        f"/users/{user_id}/roles/{role_id}",
+        headers=super_headers,
+    )
+    assert duplicate_platform_assignment.status_code == 409
+
+    blocked_role_delete = await client.delete(
+        f"/roles/{role_id}",
+        headers=super_headers,
+    )
+    assert blocked_role_delete.status_code == 400
+
+    self_permissions = await client.get(
+        "/user/permissions",
+        headers=company_one_headers,
+    )
+    assert self_permissions.status_code == 200, self_permissions.text
+    assert global_permission in self_permissions.json()["data"]
+    assert company_one_permission not in self_permissions.json()["data"]
+
+    no_membership_grant = await client.get(
+        f"/company/{company_two}/permissions",
+        headers=company_one_headers,
+    )
+    assert no_membership_grant.status_code == 403
+
+    deleted = await client.delete(
+        f"/company/{company_one}/permissions/{company_one_permission['id']}",
+        headers=company_one_headers,
+    )
+    assert deleted.status_code == 200
+    after_delete = await client.get(
+        f"/company/{company_one}/roles/{role_id}/permissions",
+        headers=company_one_headers,
+    )
+    assert after_delete.json()["data"] == [global_permission]
+
+    recreated = await client.post(
+        f"/company/{company_one}/permissions",
+        json={"name": company_one_permission["name"]},
+        headers=company_one_headers,
+    )
+    assert recreated.status_code == 201
+    assert recreated.json()["data"]["id"] != company_one_permission["id"]
+
+    removed_platform_role = await client.delete(
+        f"/users/{user_id}/roles/{role_id}",
+        headers=super_headers,
+    )
+    assert removed_platform_role.status_code == 200
+    self_permissions_after_removal = await client.get(
+        "/user/permissions",
+        headers=company_one_headers,
+    )
+    assert global_permission not in self_permissions_after_removal.json()["data"]
+
+
+async def test_duplicate_permission_and_assignment_conflicts(
+    client,
+    login_token_superuser,
+):
+    suffix = uuid4().hex
+    headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    payload = {"name": f"app.duplicate.{suffix}"}
+
+    created = await client.post("/permissions", json=payload, headers=headers)
+    duplicate = await client.post("/permissions", json=payload, headers=headers)
+
+    assert created.status_code == 201
+    assert duplicate.status_code == 409
+
+    permission_id = created.json()["data"]["id"]
+    listed = await client.get(
+        f"/permissions?name={suffix}&limit=1&page=1",
+        headers=headers,
+    )
+    assert listed.status_code == 200
+    assert listed.json()["data"]["pagination"]["total_records"] == 1
+    assert listed.json()["data"]["records"][0]["id"] == permission_id
+
+    updated = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"description": "Updated global permission"},
+        headers=headers,
+    )
+    assert updated.status_code == 200
+    assert updated.json()["data"]["description"] == "Updated global permission"
+
+    cleared = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"description": None},
+        headers=headers,
+    )
+    assert cleared.status_code == 200
+    assert cleared.json()["data"]["description"] is None
+
+    empty_update = await client.patch(
+        f"/permissions/{permission_id}",
+        json={},
+        headers=headers,
+    )
+    assert empty_update.status_code == 422
+
+    deleted = await client.delete(
+        f"/permissions/{permission_id}",
+        headers=headers,
+    )
+    assert deleted.status_code == 200
+    recreated = await client.post("/permissions", json=payload, headers=headers)
+    assert recreated.status_code == 201
+    assert recreated.json()["data"]["id"] != permission_id
+
+
+async def test_inactive_users_cannot_receive_platform_roles(
+    client,
+    login_token_superuser,
+    seed_verified_users,
+    test_user_data,
+):
+    suffix = uuid4().hex
+    headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    role_response = await client.post(
+        "/roles",
+        json={"name": f"Inactive Assignment {suffix}", "description": None},
+        headers=headers,
+    )
+    assert role_response.status_code == 201
+    role_id = role_response.json()["data"]["id"]
+
+    email = test_user_data["user_three"]["email"]
+    user_id = _user_id(email)
+    session = session_manager.session_local()
+    try:
+        user = session.query(User).filter_by(id=user_id).one()
+        metadata = dict(user.primary_meta_data or {})
+        metadata["status"] = "Suspended"
+        user.primary_meta_data = metadata
+        session.commit()
+    finally:
+        session.close()
+
+    try:
+        response = await client.post(
+            f"/users/{user_id}/roles/{role_id}",
+            headers=headers,
+        )
+        assert response.status_code == 404
+    finally:
+        session = session_manager.session_local()
+        try:
+            user = session.query(User).filter_by(id=user_id).one()
+            metadata = dict(user.primary_meta_data or {})
+            metadata["status"] = "Active"
+            user.primary_meta_data = metadata
+            session.commit()
+        finally:
+            session.close()
+
+
+async def test_permission_management_edge_cases(
+    client,
+    login_token,
+    login_token_superuser,
+    seed_companies,
+):
+    suffix = uuid4().hex
+    super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    company_headers = {"Authorization": f"Bearer {login_token}"}
+    company_id = seed_companies["company_one"]
+
+    blank_create = await client.post(
+        "/permissions",
+        json={"name": "   "},
+        headers=super_headers,
+    )
+    assert blank_create.status_code == 422
+
+    first_global = await client.post(
+        "/permissions",
+        json={
+            "name": f"  app.edge.first.{suffix}  ",
+            "description": f"Global edge description {suffix}",
+        },
+        headers=super_headers,
+    )
+    second_global = await client.post(
+        "/permissions",
+        json={"name": f"app.edge.second.{suffix}"},
+        headers=super_headers,
+    )
+    assert first_global.status_code == 201
+    assert second_global.status_code == 201
+    first_global_permission = first_global.json()["data"]
+    second_global_permission = second_global.json()["data"]
+    assert first_global_permission["name"] == f"app.edge.first.{suffix}"
+
+    global_description_filter = await client.get(
+        "/permissions",
+        params={"description": suffix, "limit": 10, "page": 1},
+        headers=super_headers,
+    )
+    assert global_description_filter.status_code == 200
+    assert [
+        record["id"] for record in global_description_filter.json()["data"]["records"]
+    ] == [first_global_permission["id"]]
+
+    null_name = await client.patch(
+        f"/permissions/{first_global_permission['id']}",
+        json={"name": None},
+        headers=super_headers,
+    )
+    blank_name = await client.patch(
+        f"/permissions/{first_global_permission['id']}",
+        json={"name": "   "},
+        headers=super_headers,
+    )
+    assert null_name.status_code == 422
+    assert blank_name.status_code == 422
+
+    renamed_global = await client.patch(
+        f"/permissions/{second_global_permission['id']}",
+        json={"name": f"app.edge.renamed.{suffix}"},
+        headers=super_headers,
+    )
+    assert renamed_global.status_code == 200
+    assert renamed_global.json()["data"]["name"] == f"app.edge.renamed.{suffix}"
+
+    global_rename_conflict = await client.patch(
+        f"/permissions/{second_global_permission['id']}",
+        json={"name": first_global_permission["name"]},
+        headers=super_headers,
+    )
+    assert global_rename_conflict.status_code == 409
+
+    missing_global_permission = await client.patch(
+        f"/permissions/{uuid4()}",
+        json={"description": "missing"},
+        headers=super_headers,
+    )
+    assert missing_global_permission.status_code == 404
+
+    first_company = await client.post(
+        f"/company/{company_id}/permissions",
+        json={
+            "name": f"  invoice.edge.first.{suffix}  ",
+            "description": f"Company edge description {suffix}",
+        },
+        headers=company_headers,
+    )
+    second_company = await client.post(
+        f"/company/{company_id}/permissions",
+        json={"name": f"invoice.edge.second.{suffix}"},
+        headers=company_headers,
+    )
+    assert first_company.status_code == 201
+    assert second_company.status_code == 201
+    first_company_permission = first_company.json()["data"]
+    second_company_permission = second_company.json()["data"]
+    assert first_company_permission["name"] == f"invoice.edge.first.{suffix}"
+
+    duplicate_company = await client.post(
+        f"/company/{company_id}/permissions",
+        json={"name": first_company_permission["name"]},
+        headers=company_headers,
+    )
+    assert duplicate_company.status_code == 409
+
+    company_permissions = await client.get(
+        f"/company/{company_id}/permissions",
+        params={"description": suffix, "limit": 10, "page": 1},
+        headers=company_headers,
+    )
+    assert company_permissions.status_code == 200
+    assert [
+        record["id"] for record in company_permissions.json()["data"]["records"]
+    ] == [first_company_permission["id"]]
+
+    superuser_company_permissions = await client.get(
+        f"/company/{company_id}/permissions",
+        params={"name": f"invoice.edge.first.{suffix}"},
+        headers=super_headers,
+    )
+    assert superuser_company_permissions.status_code == 200
+
+    renamed_company = await client.patch(
+        f"/company/{company_id}/permissions/{second_company_permission['id']}",
+        json={
+            "name": f"invoice.edge.renamed.{suffix}",
+            "description": "Renamed company permission",
+        },
+        headers=company_headers,
+    )
+    assert renamed_company.status_code == 200
+    assert renamed_company.json()["data"]["name"] == f"invoice.edge.renamed.{suffix}"
+
+    company_rename_conflict = await client.patch(
+        f"/company/{company_id}/permissions/{second_company_permission['id']}",
+        json={"name": first_company_permission["name"]},
+        headers=company_headers,
+    )
+    assert company_rename_conflict.status_code == 409
+
+    missing_company_permission = await client.patch(
+        f"/company/{company_id}/permissions/{uuid4()}",
+        json={"description": "missing"},
+        headers=company_headers,
+    )
+    assert missing_company_permission.status_code == 404
+
+    missing_company = await client.get(
+        f"/company/{uuid4()}/permissions",
+        headers=super_headers,
+    )
+    assert missing_company.status_code == 404
+
+    role_response = await client.post(
+        "/roles",
+        json={"name": f"Permission Edge Role {suffix}", "description": None},
+        headers=super_headers,
+    )
+    unassigned_role_response = await client.post(
+        "/roles",
+        json={"name": f"Unassigned Edge Role {suffix}", "description": None},
+        headers=super_headers,
+    )
+    assert role_response.status_code == 201
+    assert unassigned_role_response.status_code == 201
+    role_id = role_response.json()["data"]["id"]
+    unassigned_role_id = unassigned_role_response.json()["data"]["id"]
+
+    assigned_role = await client.post(
+        f"/company/{company_id}/roles/{role_id}",
+        headers=company_headers,
+    )
+    assert assigned_role.status_code == 201
+
+    missing_global_role = await client.get(
+        f"/roles/{uuid4()}/permissions",
+        headers=super_headers,
+    )
+    missing_company_role = await client.get(
+        f"/company/{company_id}/roles/{unassigned_role_id}/permissions",
+        headers=company_headers,
+    )
+    assert missing_global_role.status_code == 404
+    assert missing_company_role.status_code == 404
+
+    remove_missing_global_link = await client.delete(
+        f"/roles/{role_id}/permissions/{first_global_permission['id']}",
+        headers=super_headers,
+    )
+    remove_missing_company_link = await client.delete(
+        (
+            f"/company/{company_id}/roles/{role_id}/permissions/"
+            f"{first_company_permission['id']}"
+        ),
+        headers=company_headers,
+    )
+    assert remove_missing_global_link.status_code == 404
+    assert remove_missing_company_link.status_code == 404
+
+    user_id = _user_id("user.one@email.com")
+    remove_missing_platform_link = await client.delete(
+        f"/users/{user_id}/roles/{role_id}",
+        headers=super_headers,
+    )
+    assert remove_missing_platform_link.status_code == 404

--- a/tests/api/http/c_company_roles/test_i_hybrid_permissions.py
+++ b/tests/api/http/c_company_roles/test_i_hybrid_permissions.py
@@ -4,8 +4,31 @@ import pytest
 
 from app.repository.database import session_manager
 from app.repository.database.tables import CompanyRole, Role, User
+from app.models.system_permissions import SYSTEM_PERMISSION_DEFINITIONS
 
 pytestmark = pytest.mark.anyio
+
+
+def _role_fixture(data: dict, key: str, suffix: str) -> dict:
+    payload = dict(data["roles"][key])
+    payload["name"] = f"{payload['name']} {suffix}"
+    return payload
+
+
+def _permission_fixture(
+    data: dict,
+    key: str,
+    suffix: str,
+    *,
+    padded: bool = False,
+) -> dict:
+    payload = dict(data["permissions"][key])
+    payload["name"] = f"{payload['name']}.{suffix}"
+    if padded:
+        payload["name"] = f"  {payload['name']}  "
+    if payload.get("description"):
+        payload["description"] = f"{payload['description']} {suffix}"
+    return payload
 
 
 def _user_id(email: str):
@@ -40,6 +63,8 @@ async def test_hybrid_global_company_and_platform_permissions(
     login_token_user_two,
     login_token_superuser,
     seed_companies,
+    test_company_data,
+    test_global_rbac_data,
 ):
     suffix = uuid4().hex
     super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
@@ -48,23 +73,23 @@ async def test_hybrid_global_company_and_platform_permissions(
     company_one = seed_companies["company_one"]
     company_two = seed_companies["company_two"]
 
+    role_payload = _role_fixture(test_global_rbac_data, "hybrid_manager", suffix)
     role_response = await client.post(
         "/roles",
-        json={
-            "name": f"Hybrid Manager {suffix}",
-            "description": "Hybrid permission test role",
-        },
+        json=role_payload,
         headers=super_headers,
     )
     assert role_response.status_code == 201, role_response.text
     role_id = role_response.json()["data"]["id"]
 
+    global_payload = _permission_fixture(
+        test_global_rbac_data,
+        "dashboard_view",
+        suffix,
+    )
     global_response = await client.post(
         "/permissions",
-        json={
-            "name": f"app.dashboard.view.{suffix}",
-            "description": "View the platform dashboard",
-        },
+        json=global_payload,
         headers=super_headers,
     )
     assert global_response.status_code == 201, global_response.text
@@ -74,7 +99,7 @@ async def test_hybrid_global_company_and_platform_permissions(
 
     forbidden_global = await client.post(
         "/permissions",
-        json={"name": f"app.forbidden.{suffix}"},
+        json=_permission_fixture(test_global_rbac_data, "forbidden", suffix),
         headers=company_one_headers,
     )
     assert forbidden_global.status_code == 403
@@ -93,7 +118,7 @@ async def test_hybrid_global_company_and_platform_permissions(
     assert global_role_permissions.json()["data"] == [global_permission]
     global_role_list = await client.get(
         "/roles",
-        params={"name": f"Hybrid Manager {suffix}"},
+        params={"name": role_payload["name"]},
         headers=super_headers,
     )
     assert global_role_list.status_code == 200
@@ -117,12 +142,14 @@ async def test_hybrid_global_company_and_platform_permissions(
         assert response.status_code == 201, response.text
         assert response.json()["data"]["permissions"] == [global_permission]
 
+    company_permission_payload = _permission_fixture(
+        test_company_data,
+        "invoice_approve",
+        suffix,
+    )
     company_one_permission_response = await client.post(
         f"/company/{company_one}/permissions",
-        json={
-            "name": f"invoice.approve.{suffix}",
-            "description": "Approve invoices for company one",
-        },
+        json=company_permission_payload,
         headers=company_one_headers,
     )
     assert company_one_permission_response.status_code == 201
@@ -132,10 +159,7 @@ async def test_hybrid_global_company_and_platform_permissions(
 
     company_two_permission_response = await client.post(
         f"/company/{company_two}/permissions",
-        json={
-            "name": f"invoice.approve.{suffix}",
-            "description": "Same tenant-local name for company two",
-        },
+        json=company_permission_payload,
         headers=company_two_headers,
     )
     assert company_two_permission_response.status_code == 201
@@ -214,9 +238,15 @@ async def test_hybrid_global_company_and_platform_permissions(
         for record in user_companies.json()["data"]["records"]
         if record["id"] == str(company_one)
     )
+    owner_system_permission_ids = {
+        str(definition.id)
+        for definition in SYSTEM_PERMISSION_DEFINITIONS
+        if "Owner" in definition.default_roles
+    }
     assert {item["id"] for item in company_record["role"]["permissions"]} == {
         global_permission["id"],
         company_one_permission["id"],
+        *owner_system_permission_ids,
     }
 
     company_users = await client.get(
@@ -231,6 +261,7 @@ async def test_hybrid_global_company_and_platform_permissions(
     assert {item["id"] for item in owner_record["role"]["permissions"]} == {
         global_permission["id"],
         company_one_permission["id"],
+        *owner_system_permission_ids,
     }
 
     await client.delete(
@@ -325,10 +356,11 @@ async def test_hybrid_global_company_and_platform_permissions(
 async def test_duplicate_permission_and_assignment_conflicts(
     client,
     login_token_superuser,
+    test_global_rbac_data,
 ):
     suffix = uuid4().hex
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
-    payload = {"name": f"app.duplicate.{suffix}"}
+    payload = _permission_fixture(test_global_rbac_data, "duplicate", suffix)
 
     created = await client.post("/permissions", json=payload, headers=headers)
     duplicate = await client.post("/permissions", json=payload, headers=headers)
@@ -383,12 +415,13 @@ async def test_inactive_users_cannot_receive_platform_roles(
     login_token_superuser,
     seed_verified_users,
     test_user_data,
+    test_global_rbac_data,
 ):
     suffix = uuid4().hex
     headers = {"Authorization": f"Bearer {login_token_superuser}"}
     role_response = await client.post(
         "/roles",
-        json={"name": f"Inactive Assignment {suffix}", "description": None},
+        json=_role_fixture(test_global_rbac_data, "inactive_assignment", suffix),
         headers=headers,
     )
     assert role_response.status_code == 201
@@ -429,6 +462,8 @@ async def test_permission_management_edge_cases(
     login_token,
     login_token_superuser,
     seed_companies,
+    test_company_data,
+    test_global_rbac_data,
 ):
     suffix = uuid4().hex
     super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
@@ -442,24 +477,32 @@ async def test_permission_management_edge_cases(
     )
     assert blank_create.status_code == 422
 
+    first_global_payload = _permission_fixture(
+        test_global_rbac_data,
+        "edge_first",
+        suffix,
+        padded=True,
+    )
+    second_global_payload = _permission_fixture(
+        test_global_rbac_data,
+        "edge_second",
+        suffix,
+    )
     first_global = await client.post(
         "/permissions",
-        json={
-            "name": f"  app.edge.first.{suffix}  ",
-            "description": f"Global edge description {suffix}",
-        },
+        json=first_global_payload,
         headers=super_headers,
     )
     second_global = await client.post(
         "/permissions",
-        json={"name": f"app.edge.second.{suffix}"},
+        json=second_global_payload,
         headers=super_headers,
     )
     assert first_global.status_code == 201
     assert second_global.status_code == 201
     first_global_permission = first_global.json()["data"]
     second_global_permission = second_global.json()["data"]
-    assert first_global_permission["name"] == f"app.edge.first.{suffix}"
+    assert first_global_permission["name"] == first_global_payload["name"].strip()
 
     global_description_filter = await client.get(
         "/permissions",
@@ -484,13 +527,18 @@ async def test_permission_management_edge_cases(
     assert null_name.status_code == 422
     assert blank_name.status_code == 422
 
+    renamed_global_payload = _permission_fixture(
+        test_global_rbac_data,
+        "edge_renamed",
+        suffix,
+    )
     renamed_global = await client.patch(
         f"/permissions/{second_global_permission['id']}",
-        json={"name": f"app.edge.renamed.{suffix}"},
+        json={"name": renamed_global_payload["name"]},
         headers=super_headers,
     )
     assert renamed_global.status_code == 200
-    assert renamed_global.json()["data"]["name"] == f"app.edge.renamed.{suffix}"
+    assert renamed_global.json()["data"]["name"] == renamed_global_payload["name"]
 
     global_rename_conflict = await client.patch(
         f"/permissions/{second_global_permission['id']}",
@@ -506,24 +554,32 @@ async def test_permission_management_edge_cases(
     )
     assert missing_global_permission.status_code == 404
 
+    first_company_payload = _permission_fixture(
+        test_company_data,
+        "edge_first",
+        suffix,
+        padded=True,
+    )
+    second_company_payload = _permission_fixture(
+        test_company_data,
+        "edge_second",
+        suffix,
+    )
     first_company = await client.post(
         f"/company/{company_id}/permissions",
-        json={
-            "name": f"  invoice.edge.first.{suffix}  ",
-            "description": f"Company edge description {suffix}",
-        },
+        json=first_company_payload,
         headers=company_headers,
     )
     second_company = await client.post(
         f"/company/{company_id}/permissions",
-        json={"name": f"invoice.edge.second.{suffix}"},
+        json=second_company_payload,
         headers=company_headers,
     )
     assert first_company.status_code == 201
     assert second_company.status_code == 201
     first_company_permission = first_company.json()["data"]
     second_company_permission = second_company.json()["data"]
-    assert first_company_permission["name"] == f"invoice.edge.first.{suffix}"
+    assert first_company_permission["name"] == first_company_payload["name"].strip()
 
     duplicate_company = await client.post(
         f"/company/{company_id}/permissions",
@@ -544,21 +600,26 @@ async def test_permission_management_edge_cases(
 
     superuser_company_permissions = await client.get(
         f"/company/{company_id}/permissions",
-        params={"name": f"invoice.edge.first.{suffix}"},
+        params={"name": first_company_permission["name"]},
         headers=super_headers,
     )
     assert superuser_company_permissions.status_code == 200
 
+    renamed_company_payload = _permission_fixture(
+        test_company_data,
+        "edge_renamed",
+        suffix,
+    )
     renamed_company = await client.patch(
         f"/company/{company_id}/permissions/{second_company_permission['id']}",
         json={
-            "name": f"invoice.edge.renamed.{suffix}",
-            "description": "Renamed company permission",
+            "name": renamed_company_payload["name"],
+            "description": renamed_company_payload["description"],
         },
         headers=company_headers,
     )
     assert renamed_company.status_code == 200
-    assert renamed_company.json()["data"]["name"] == f"invoice.edge.renamed.{suffix}"
+    assert renamed_company.json()["data"]["name"] == renamed_company_payload["name"]
 
     company_rename_conflict = await client.patch(
         f"/company/{company_id}/permissions/{second_company_permission['id']}",
@@ -582,12 +643,12 @@ async def test_permission_management_edge_cases(
 
     role_response = await client.post(
         "/roles",
-        json={"name": f"Permission Edge Role {suffix}", "description": None},
+        json=_role_fixture(test_global_rbac_data, "permission_edge", suffix),
         headers=super_headers,
     )
     unassigned_role_response = await client.post(
         "/roles",
-        json={"name": f"Unassigned Edge Role {suffix}", "description": None},
+        json=_role_fixture(test_global_rbac_data, "unassigned_edge", suffix),
         headers=super_headers,
     )
     assert role_response.status_code == 201

--- a/tests/api/http/conftest.py
+++ b/tests/api/http/conftest.py
@@ -20,6 +20,7 @@ from app.models.user.account_status import UserAccountStatus
 from app.models.user.user import UserReadModel
 from app.configs import settings
 from app.repository.database.session_manager import DatabaseSessionManager
+from app.repository.company import CompanyRepository
 from app.repository.database.tables import AssociationUserCompany, Company, Role, User
 from app.repository.database.tables import CompanyRole
 import app.repository.database.session_manager as session_manager
@@ -199,6 +200,12 @@ def test_user_data():
 @pytest.fixture(scope="session")
 def test_company_data():
     with open(f"{TEST_DATA_BASE_PATH}company.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def test_global_rbac_data():
+    with open(f"{TEST_DATA_BASE_PATH}global_rbac.json") as f:
         return json.load(f)
 
 
@@ -674,6 +681,8 @@ def seed_pagination_state():
         owner_role_name = CompanyDefaultRoles.OWNER.name_value
         administrator_role_name = CompanyDefaultRoles.ADMINISTRATOR.name_value
         viewer_role_name = CompanyDefaultRoles.VIEWER.name_value
+
+        CompanyRepository(session)._ensure_default_roles()
 
         for company_id in company_ids:
             for default_role in CompanyDefaultRoles:

--- a/tests/api/http/d_company_users/test_h_get_company_users.py
+++ b/tests/api/http/d_company_users/test_h_get_company_users.py
@@ -66,6 +66,7 @@ async def test_get_users_for_company(
     query_params,
     expected_emails,
     expected_status,
+    test_company_data,
 ):
     """
     Test retrieving users in a company using both users' tokens and checking role/user filters.
@@ -100,7 +101,9 @@ async def test_get_users_for_company(
             assert "role_id" not in user
             assert "role_name" not in user
             assert set(user["role"]) == {"id", "name", "description", "permissions"}
-            assert user["role"]["permissions"] == []
+            assert {
+                permission["name"] for permission in user["role"]["permissions"]
+            } == set(test_company_data["default_roles"]["owner"]["permissions"])
         pagination = json_data["data"]["pagination"]
         assert pagination["limit"] == 10
         assert pagination["current_page"] == 1
@@ -119,6 +122,7 @@ async def test_get_users_for_company_returns_nested_role_details(
     login_token,
     seed_companies,
     verify_both_users,
+    test_company_data,
 ):
     response = await client.get(
         f"/company/{seed_companies['company_one']}/users?limit=10&page=1",
@@ -131,9 +135,10 @@ async def test_get_users_for_company_returns_nested_role_details(
     assert response.status_code == 200, response.text
     record = response.json()["data"]["records"][0]
     assert record["email"] == "user.one@email.com"
-    assert record["role"] == {
-        "id": record["role"]["id"],
-        "name": "Owner",
-        "description": "Full access to manage users and data",
-        "permissions": [],
-    }
+    assert record["role"]["id"]
+    owner_role = test_company_data["default_roles"]["owner"]
+    assert record["role"]["name"] == owner_role["name"]
+    assert record["role"]["description"] == owner_role["description"]
+    assert {permission["name"] for permission in record["role"]["permissions"]} == set(
+        owner_role["permissions"]
+    )

--- a/tests/api/http/d_company_users/test_i_get_user_companies.py
+++ b/tests/api/http/d_company_users/test_i_get_user_companies.py
@@ -48,6 +48,7 @@ async def test_get_user_companies(
     query_params,
     expected_company_ids,
     expected_status,
+    test_company_data,
 ):
     """
     Test /user/companies with various filters and users.
@@ -75,11 +76,14 @@ async def test_get_user_companies(
         }
         company_ids = {company["id"] for company in json_data["data"]["records"]}
         assert company_ids == expected_company_ids
+        owner_role = test_company_data["default_roles"]["owner"]
         for company in json_data["data"]["records"]:
             assert company["role"]["id"]
-            assert company["role"]["name"] == "Owner"
-            assert company["role"]["description"]
-            assert company["role"]["permissions"] == []
+            assert company["role"]["name"] == owner_role["name"]
+            assert company["role"]["description"] == owner_role["description"]
+            assert {
+                permission["name"] for permission in company["role"]["permissions"]
+            } == set(owner_role["permissions"])
 
         pagination = json_data["data"]["pagination"]
         assert pagination["limit"] == 10

--- a/tests/api/http/d_company_users/test_m_openapi_role_schema.py
+++ b/tests/api/http/d_company_users/test_m_openapi_role_schema.py
@@ -25,7 +25,7 @@ def test_openapi_documents_nested_company_user_role_schema():
         "$ref": "#/components/schemas/RoleReadModel"
     }
     assert role_schema["properties"]["permissions"] == {
-        "items": {"type": "string"},
+        "items": {"$ref": "#/components/schemas/PermissionReadModel"},
         "type": "array",
         "title": "Permissions",
     }

--- a/tests/api/http/test_default_permission_enforcement.py
+++ b/tests/api/http/test_default_permission_enforcement.py
@@ -1,0 +1,331 @@
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.models.system_permissions import SYSTEM_PERMISSION_BY_ID, SystemPermission
+from app.repository.database import session_manager
+from app.repository.database.tables import CompanyRole, Role, User
+
+pytestmark = pytest.mark.anyio
+
+
+def _user_id(email: str):
+    session = session_manager.session_local()
+    try:
+        return session.query(User.id).filter_by(email=email.lower()).scalar()
+    finally:
+        session.close()
+
+
+def _company_role_id(company_id, name: str):
+    company_id = UUID(str(company_id))
+    session = session_manager.session_local()
+    try:
+        return (
+            session.query(Role.id)
+            .join(CompanyRole, CompanyRole.role_id == Role.id)
+            .filter(
+                CompanyRole.company_id == company_id,
+                CompanyRole._closed_at.is_(None),
+                Role.name == name,
+                Role._closed_at.is_(None),
+            )
+            .scalar()
+        )
+    finally:
+        session.close()
+
+
+async def test_default_role_endpoint_matrix_and_superuser_bypass(
+    client,
+    login_token,
+    login_token_user_two,
+    login_token_superuser,
+    seed_verified_users,
+    test_company_data,
+    test_global_rbac_data,
+):
+    suffix = uuid4().hex
+    owner_headers = {"Authorization": f"Bearer {login_token}"}
+    member_headers = {"Authorization": f"Bearer {login_token_user_two}"}
+    super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    rbac_company = test_company_data["rbac_company"]
+    company_payload = {
+        **test_company_data["company_one"],
+        "name": f"{rbac_company['name']} {suffix}",
+        "email": f"{rbac_company['email_prefix']}-{suffix}@example.com",
+        "description": rbac_company["description"],
+        "address": test_company_data["json_field"]["value"],
+    }
+    created_company = await client.post(
+        "/company",
+        json=company_payload,
+        headers=owner_headers,
+    )
+    assert created_company.status_code == 201, created_company.text
+    company_id = created_company.json()["data"]["id"]
+    user_two_id = _user_id("user.two@email.com")
+    user_three_id = _user_id("user.three@email.com")
+
+    added_viewer = await client.post(
+        f"/company/{company_id}/users",
+        json={"email": "user.two@email.com", "role": "Viewer"},
+        headers=owner_headers,
+    )
+    assert added_viewer.status_code == 201, added_viewer.text
+
+    viewer_allowed_requests = (
+        ("get", "/company", {"params": {"company_id": company_id}}),
+        ("get", f"/company/{company_id}/users", {}),
+    )
+    for method, path, kwargs in viewer_allowed_requests:
+        response = await getattr(client, method)(path, headers=member_headers, **kwargs)
+        assert response.status_code == 200, response.text
+
+    missing_id = uuid4()
+    matrix_permission = test_company_data["permissions"]["matrix_permission"]
+    matrix_permission_name = f"{matrix_permission['name']}.{suffix}"
+    viewer_denied_requests = (
+        ("patch", f"/company/{company_id}", {"json": {"description": "Denied"}}),
+        ("delete", f"/company/{company_id}", {}),
+        (
+            "post",
+            f"/company/{company_id}/users",
+            {"json": {"email": "user.three@email.com", "role": "Viewer"}},
+        ),
+        (
+            "patch",
+            f"/company/{company_id}/user/{user_two_id}",
+            {"json": {"role": "Administrator"}},
+        ),
+        ("delete", f"/company/{company_id}/user/{user_two_id}", {}),
+        ("get", f"/company/{company_id}/roles", {}),
+        ("post", f"/company/{company_id}/roles/{missing_id}", {}),
+        ("delete", f"/company/{company_id}/roles/{missing_id}", {}),
+        (
+            "post",
+            f"/company/{company_id}/permissions",
+            {"json": {"name": matrix_permission_name}},
+        ),
+        ("get", f"/company/{company_id}/permissions", {}),
+        (
+            "patch",
+            f"/company/{company_id}/permissions/{missing_id}",
+            {"json": {"description": "Denied"}},
+        ),
+        ("delete", f"/company/{company_id}/permissions/{missing_id}", {}),
+        (
+            "get",
+            f"/company/{company_id}/roles/{missing_id}/permissions",
+            {},
+        ),
+        (
+            "post",
+            f"/company/{company_id}/roles/{missing_id}/permissions/{missing_id}",
+            {},
+        ),
+        (
+            "delete",
+            f"/company/{company_id}/roles/{missing_id}/permissions/{missing_id}",
+            {},
+        ),
+    )
+    for method, path, kwargs in viewer_denied_requests:
+        response = await getattr(client, method)(path, headers=member_headers, **kwargs)
+        assert response.status_code == 403, (method, path, response.text)
+
+    promoted = await client.patch(
+        f"/company/{company_id}/user/{user_two_id}",
+        json={"role": "Administrator"},
+        headers=owner_headers,
+    )
+    assert promoted.status_code == 200, promoted.text
+
+    company_read = await client.get(
+        "/company",
+        params={"company_id": company_id},
+        headers=member_headers,
+    )
+    company_update = await client.patch(
+        f"/company/{company_id}",
+        json={"description": "Managed by Administrator"},
+        headers=member_headers,
+    )
+    members_read = await client.get(
+        f"/company/{company_id}/users",
+        headers=member_headers,
+    )
+    assert company_read.status_code == 200
+    assert company_update.status_code == 200
+    assert members_read.status_code == 200
+
+    added_member = await client.post(
+        f"/company/{company_id}/users",
+        json={"email": "user.three@email.com", "role": "Viewer"},
+        headers=member_headers,
+    )
+    assert added_member.status_code == 201, added_member.text
+    updated_member = await client.patch(
+        f"/company/{company_id}/user/{user_three_id}",
+        json={"role": "Administrator"},
+        headers=member_headers,
+    )
+    assert updated_member.status_code == 200, updated_member.text
+    removed_member = await client.delete(
+        f"/company/{company_id}/user/{user_three_id}",
+        headers=member_headers,
+    )
+    assert removed_member.status_code == 200, removed_member.text
+
+    roles_read = await client.get(
+        f"/company/{company_id}/roles",
+        headers=member_headers,
+    )
+    assert roles_read.status_code == 200, roles_read.text
+    matrix_role = test_global_rbac_data["roles"]["matrix_role"]
+    global_role = await client.post(
+        "/roles",
+        json={
+            **matrix_role,
+            "name": f"{matrix_role['name']} {suffix}",
+        },
+        headers=super_headers,
+    )
+    assert global_role.status_code == 201, global_role.text
+    role_id = global_role.json()["data"]["id"]
+    assigned_role = await client.post(
+        f"/company/{company_id}/roles/{role_id}",
+        headers=member_headers,
+    )
+    assert assigned_role.status_code == 201, assigned_role.text
+    unassigned_role = await client.delete(
+        f"/company/{company_id}/roles/{role_id}",
+        headers=member_headers,
+    )
+    assert unassigned_role.status_code == 200, unassigned_role.text
+
+    created_permission = await client.post(
+        f"/company/{company_id}/permissions",
+        json={
+            **matrix_permission,
+            "name": matrix_permission_name,
+        },
+        headers=member_headers,
+    )
+    assert created_permission.status_code == 201, created_permission.text
+    permission_id = created_permission.json()["data"]["id"]
+    listed_permissions = await client.get(
+        f"/company/{company_id}/permissions",
+        headers=member_headers,
+    )
+    updated_permission = await client.patch(
+        f"/company/{company_id}/permissions/{permission_id}",
+        json={"description": "Updated by Administrator"},
+        headers=member_headers,
+    )
+    assert listed_permissions.status_code == 200
+    assert updated_permission.status_code == 200
+
+    viewer_role_id = _company_role_id(company_id, "Viewer")
+    assigned_permission = await client.post(
+        (
+            f"/company/{company_id}/roles/{viewer_role_id}/permissions/"
+            f"{permission_id}"
+        ),
+        headers=member_headers,
+    )
+    assert assigned_permission.status_code == 201, assigned_permission.text
+    effective_permissions = await client.get(
+        f"/company/{company_id}/roles/{viewer_role_id}/permissions",
+        headers=member_headers,
+    )
+    assert effective_permissions.status_code == 200, effective_permissions.text
+    removed_permission_link = await client.delete(
+        (
+            f"/company/{company_id}/roles/{viewer_role_id}/permissions/"
+            f"{permission_id}"
+        ),
+        headers=member_headers,
+    )
+    assert removed_permission_link.status_code == 200, removed_permission_link.text
+    deleted_permission = await client.delete(
+        f"/company/{company_id}/permissions/{permission_id}",
+        headers=member_headers,
+    )
+    assert deleted_permission.status_code == 200, deleted_permission.text
+
+    administrator_delete = await client.delete(
+        f"/company/{company_id}",
+        headers=member_headers,
+    )
+    assert administrator_delete.status_code == 403
+
+    for path in (
+        f"/company?company_id={company_id}",
+        f"/company/{company_id}/users",
+        f"/company/{company_id}/roles",
+        f"/company/{company_id}/permissions",
+    ):
+        superuser_response = await client.get(path, headers=super_headers)
+        assert superuser_response.status_code == 200, superuser_response.text
+
+    owner_delete = await client.delete(
+        f"/company/{company_id}",
+        headers=owner_headers,
+    )
+    assert owner_delete.status_code == 200, owner_delete.text
+
+
+async def test_system_permissions_allow_description_only_updates(
+    client,
+    login_token,
+    login_token_superuser,
+    seed_companies,
+    test_company_data,
+):
+    super_headers = {"Authorization": f"Bearer {login_token_superuser}"}
+    permission_id = SystemPermission.COMPANY_READ.permission_id
+
+    updated = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"description": "Updated system permission description"},
+        headers=super_headers,
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["data"]["name"] == SystemPermission.COMPANY_READ.value
+
+    unchanged_name = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"name": SystemPermission.COMPANY_READ.value},
+        headers=super_headers,
+    )
+    assert unchanged_name.status_code == 200, unchanged_name.text
+
+    renamed = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"name": "company.read.renamed"},
+        headers=super_headers,
+    )
+    deleted = await client.delete(
+        f"/permissions/{permission_id}",
+        headers=super_headers,
+    )
+    assert renamed.status_code == 409
+    assert deleted.status_code == 409
+
+    restored = await client.patch(
+        f"/permissions/{permission_id}",
+        json={"description": SYSTEM_PERMISSION_BY_ID[permission_id].description},
+        headers=super_headers,
+    )
+    assert restored.status_code == 200, restored.text
+
+    collision_permission = test_company_data["permissions"]["system_name_collision"]
+    tenant_same_name = await client.post(
+        f"/company/{seed_companies['company_one']}/permissions",
+        json=collision_permission,
+        headers={"Authorization": f"Bearer {login_token}"},
+    )
+    assert tenant_same_name.status_code == 201, tenant_same_name.text
+    assert tenant_same_name.json()["data"]["scope"] == "company"
+    assert tenant_same_name.json()["data"]["name"] == collision_permission["name"]

--- a/tests/api/http/test_exceptions.py
+++ b/tests/api/http/test_exceptions.py
@@ -1,4 +1,7 @@
+import builtins
 from types import SimpleNamespace
+
+import app.exceptions as exception_module
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -194,3 +197,31 @@ def test_unwrap_exception_handles_exception_groups():
     root, trail = unwrap_exception(group)
     assert isinstance(root, ValueError)
     assert trail == ["ExceptionGroup", "ValueError"]
+
+
+def test_unwrap_exception_handles_empty_group_compatible_object(monkeypatch):
+    class EmptyGroup(Exception):
+        exceptions = []
+
+    monkeypatch.setattr(
+        exception_module,
+        "BaseExceptionGroup",
+        EmptyGroup,
+        raising=False,
+    )
+    empty_group = EmptyGroup("empty")
+
+    root, trail = unwrap_exception(empty_group)
+
+    assert root is empty_group
+    assert trail == ["EmptyGroup"]
+
+
+def test_unwrap_exception_supports_python_without_exception_groups(monkeypatch):
+    monkeypatch.delattr(builtins, "BaseExceptionGroup")
+    error = RuntimeError("legacy runtime")
+
+    root, trail = unwrap_exception(error)
+
+    assert root is error
+    assert trail == ["RuntimeError"]

--- a/tests/api/http/test_pagination_regressions.py
+++ b/tests/api/http/test_pagination_regressions.py
@@ -88,7 +88,7 @@ async def test_get_user_companies_page_two_is_stable(client, seed_pagination_sta
 
 
 async def test_get_user_companies_returns_company_specific_roles(
-    client, seed_pagination_state
+    client, seed_pagination_state, test_company_data
 ):
     headers = {"Authorization": f"Bearer {seed_pagination_state['owner_token']}"}
 
@@ -114,10 +114,18 @@ async def test_get_user_companies_returns_company_specific_roles(
             "postal_code": "2000",
             "country": "South Africa",
         }
-        assert company["role"] == {
-            **expected_role,
-            "permissions": [],
-        }
+        permissions = company["role"].pop("permissions")
+        assert company["role"] == expected_role
+        default_role = next(
+            role
+            for role in test_company_data["default_roles"].values()
+            if role["name"] == expected_role["name"]
+        )
+        assert {permission["name"] for permission in permissions} == set(
+            default_role["permissions"]
+        )
+        assert all(permission["scope"] == "global" for permission in permissions)
+        assert all(permission["company_id"] is None for permission in permissions)
 
     assert json_data["data"]["pagination"] == {
         "total_records": 4,

--- a/tests/api/http/test_rbac_fixture_data.py
+++ b/tests/api/http/test_rbac_fixture_data.py
@@ -1,0 +1,35 @@
+from app.models.company.roles import CompanyDefaultRoles
+from app.models.system_permissions import SYSTEM_PERMISSION_DEFINITIONS
+
+
+def test_company_rbac_fixture_matches_default_role_registry(test_company_data):
+    fixture_roles = test_company_data["default_roles"]
+    expected_roles = {role.name_value: role.description for role in CompanyDefaultRoles}
+
+    assert {
+        role["name"]: role["description"] for role in fixture_roles.values()
+    } == expected_roles
+
+    for role in fixture_roles.values():
+        assert set(role["permissions"]) == {
+            definition.name
+            for definition in SYSTEM_PERMISSION_DEFINITIONS
+            if role["name"] in definition.default_roles
+        }
+
+
+def test_global_rbac_fixture_has_unique_role_and_permission_names(
+    test_global_rbac_data,
+):
+    roles = test_global_rbac_data["roles"]
+    permissions = test_global_rbac_data["permissions"]
+    role_names = [role["name"] for role in roles.values()]
+    permission_names = [permission["name"] for permission in permissions.values()]
+
+    assert len(role_names) == len(set(role_names))
+    assert len(permission_names) == len(set(permission_names))
+    assert all("description" in role for role in roles.values())
+    assert all("description" in permission for permission in permissions.values())
+    assert set(permission_names).isdisjoint(
+        definition.name for definition in SYSTEM_PERMISSION_DEFINITIONS
+    )

--- a/tests/api/security/test_jwt.py
+++ b/tests/api/security/test_jwt.py
@@ -76,6 +76,25 @@ def test_decode_refresh_token_invalid_version_defaults_to_zero():
     assert refresh_token_version == 0
 
 
+def test_decode_access_token_invalid_version_defaults_to_zero():
+    jwt_manager = JWTManager()
+    token = jwt.encode(
+        {
+            "user": sample_user.model_dump(mode="json"),
+            "type": "access",
+            "refresh_token_version": {"invalid": "mapping"},
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        },
+        jwt_manager.JWT_SECRET,
+        algorithm=jwt_manager.JWT_ALGORITHM,
+    )
+
+    user, refresh_token_version = jwt_manager.decode_access_token(token)
+
+    assert user.email == sample_user.email
+    assert refresh_token_version == 0
+
+
 def test_decode_token_missing_user_data():
     jwt_manager = JWTManager()
     token = jwt.encode(

--- a/tests/data/http/company.json
+++ b/tests/data/http/company.json
@@ -13,7 +13,7 @@
         "industry": "Technology",
         "phone_number": "+27123456789"
     },
-    "roles":{
+    "roles": {
         "user": {
             "name": "User",
             "description": "Standard user role with limited access."
@@ -22,6 +22,90 @@
             "name": "Client",
             "description": "Client role with access to client-specific features."
         }
+    },
+    "default_roles": {
+        "owner": {
+            "name": "Owner",
+            "description": "Full access to manage users and data",
+            "permissions": [
+                "company.read",
+                "company.update",
+                "company.delete",
+                "company.members.read",
+                "company.members.add",
+                "company.members.role.update",
+                "company.members.remove",
+                "company.roles.read",
+                "company.roles.assign",
+                "company.roles.unassign",
+                "company.permissions.read",
+                "company.permissions.create",
+                "company.permissions.update",
+                "company.permissions.delete",
+                "company.permissions.assign",
+                "company.permissions.unassign"
+            ]
+        },
+        "administrator": {
+            "name": "Administrator",
+            "description": "Full access to manage users and data",
+            "permissions": [
+                "company.read",
+                "company.update",
+                "company.members.read",
+                "company.members.add",
+                "company.members.role.update",
+                "company.members.remove",
+                "company.roles.read",
+                "company.roles.assign",
+                "company.roles.unassign",
+                "company.permissions.read",
+                "company.permissions.create",
+                "company.permissions.update",
+                "company.permissions.delete",
+                "company.permissions.assign",
+                "company.permissions.unassign"
+            ]
+        },
+        "viewer": {
+            "name": "Viewer",
+            "description": "Read-only access to company data",
+            "permissions": [
+                "company.read",
+                "company.members.read"
+            ]
+        }
+    },
+    "permissions": {
+        "invoice_approve": {
+            "name": "invoice.approve",
+            "description": "Approve invoices for this company"
+        },
+        "matrix_permission": {
+            "name": "matrix.permission",
+            "description": "Permission used by the default-role API matrix"
+        },
+        "edge_first": {
+            "name": "invoice.edge.first",
+            "description": "Company permission edge-case fixture"
+        },
+        "edge_second": {
+            "name": "invoice.edge.second",
+            "description": null
+        },
+        "edge_renamed": {
+            "name": "invoice.edge.renamed",
+            "description": "Renamed company permission"
+        },
+        "system_name_collision": {
+            "name": "company.delete",
+            "description": "Tenant permission that must not grant company deletion"
+        }
+    },
+    "rbac_company": {
+        "name": "Permission Matrix Company",
+        "email_prefix": "permission-matrix",
+        "description": "Company used to verify default permission enforcement"
     },
     "update_company_one": {
         "name": "Updated Company One",

--- a/tests/data/http/global_rbac.json
+++ b/tests/data/http/global_rbac.json
@@ -1,0 +1,54 @@
+{
+    "roles": {
+        "managed": {
+            "name": "Global Role",
+            "description": "Global role management fixture"
+        },
+        "hybrid_manager": {
+            "name": "Hybrid Manager",
+            "description": "Hybrid global and company permission fixture"
+        },
+        "matrix_role": {
+            "name": "Matrix Role",
+            "description": "Role used by the default permission API matrix"
+        },
+        "inactive_assignment": {
+            "name": "Inactive Assignment",
+            "description": "Role used to reject inactive platform users"
+        },
+        "permission_edge": {
+            "name": "Permission Edge Role",
+            "description": null
+        },
+        "unassigned_edge": {
+            "name": "Unassigned Edge Role",
+            "description": null
+        }
+    },
+    "permissions": {
+        "dashboard_view": {
+            "name": "app.dashboard.view",
+            "description": "View the platform dashboard"
+        },
+        "forbidden": {
+            "name": "app.forbidden",
+            "description": null
+        },
+        "duplicate": {
+            "name": "app.duplicate",
+            "description": null
+        },
+        "edge_first": {
+            "name": "app.edge.first",
+            "description": "Global permission edge-case fixture"
+        },
+        "edge_second": {
+            "name": "app.edge.second",
+            "description": null
+        },
+        "edge_renamed": {
+            "name": "app.edge.renamed",
+            "description": "Renamed global permission"
+        }
+    }
+}

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -196,7 +196,9 @@ def test_company_repository_get_user_companies_uses_fixed_select_count(test_sess
         event.remove(test_session.bind, "before_cursor_execute", record_select)
 
     assert len(result.records) == 3
-    assert len(select_statements) == 2
+    # Count + page + one bulk query per permission scope. The query count stays
+    # constant as company memberships are added.
+    assert len(select_statements) == 4
 
 
 def test_company_repository_ensure_default_roles_updates_description(monkeypatch):

--- a/tests/database/test_company_extra.py
+++ b/tests/database/test_company_extra.py
@@ -209,6 +209,10 @@ def test_company_repository_ensure_default_roles_updates_description(monkeypatch
     query.filter.return_value.one_or_none.side_effect = [role, None, None]
     session.query.return_value = query
     session.commit = Mock()
+    monkeypatch.setattr(
+        "app.repository.permission.SystemPermissionRepository.seed_new_default_roles",
+        lambda self, roles, created_role_names: None,
+    )
 
     default_roles = repository._ensure_default_roles()
 

--- a/tests/database/test_default_permission_migration.py
+++ b/tests/database/test_default_permission_migration.py
@@ -1,0 +1,109 @@
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.models.system_permissions import SYSTEM_PERMISSION_DEFINITIONS
+from app.repository.database.tables import (
+    GlobalPermission,
+    Role,
+    RoleGlobalPermission,
+)
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "alembic/versions/c9f4a6b8d210_seed_default_api_permissions.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(
+        "seed_default_api_permissions_migration",
+        MIGRATION_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_permission_migration_upgrade_is_idempotent_and_reversible(
+    test_session,
+    monkeypatch,
+):
+    roles = {
+        role_name: Role(name=role_name, description=f"{role_name} role")
+        for role_name in ("Owner", "Administrator", "Viewer")
+    }
+    test_session.add_all(roles.values())
+    custom_permission = GlobalPermission(
+        name="app.custom.retained",
+        description="Must survive the system-permission downgrade",
+    )
+    test_session.add(custom_permission)
+    test_session.flush()
+    test_session.add(
+        RoleGlobalPermission(
+            role_id=roles["Owner"].id,
+            global_permission_id=custom_permission.id,
+        )
+    )
+    test_session.commit()
+    migration = _load_migration()
+    monkeypatch.setattr(migration.op, "get_bind", test_session.connection)
+
+    migration.upgrade()
+    migration.upgrade()
+    test_session.expire_all()
+
+    assert test_session.query(GlobalPermission).count() == (
+        len(SYSTEM_PERMISSION_DEFINITIONS) + 1
+    )
+    for definition in SYSTEM_PERMISSION_DEFINITIONS:
+        permission = test_session.get(GlobalPermission, definition.id)
+        assert permission.name == definition.name
+        linked_role_names = {
+            role_name
+            for (role_name,) in test_session.query(Role.name)
+            .join(RoleGlobalPermission, RoleGlobalPermission.role_id == Role.id)
+            .filter(RoleGlobalPermission.global_permission_id == definition.id)
+            .all()
+        }
+        assert linked_role_names == set(definition.default_roles)
+
+    migration.downgrade()
+    test_session.expire_all()
+
+    assert test_session.query(GlobalPermission).all() == [custom_permission]
+    assert test_session.query(RoleGlobalPermission).count() == 1
+    assert (
+        test_session.query(RoleGlobalPermission)
+        .filter_by(
+            role_id=roles["Owner"].id,
+            global_permission_id=custom_permission.id,
+        )
+        .one_or_none()
+        is not None
+    )
+    assert test_session.query(Role).count() == 3
+
+
+def test_default_permission_migration_rejects_reserved_name_conflict(
+    test_session,
+    monkeypatch,
+):
+    definition = SYSTEM_PERMISSION_DEFINITIONS[0]
+    test_session.add(
+        GlobalPermission(
+            id=uuid4(),
+            name=definition.name,
+            description="Existing conflicting permission",
+        )
+    )
+    test_session.commit()
+    migration = _load_migration()
+    monkeypatch.setattr(migration.op, "get_bind", test_session.connection)
+
+    with pytest.raises(RuntimeError, match="Reserved system permission conflict"):
+        migration.upgrade()

--- a/tests/database/test_permission_repository.py
+++ b/tests/database/test_permission_repository.py
@@ -1,0 +1,44 @@
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.repository.database.tables import Role
+from app.repository.permission import (
+    CompanyPermissionRepository,
+    RolePermissionRepository,
+)
+from app.utils.app_error import AppError
+
+
+def test_company_permission_assignment_translates_constraint_race(monkeypatch):
+    session = Mock()
+    session.query.return_value.filter_by.return_value.one_or_none.return_value = None
+    session.commit.side_effect = IntegrityError(
+        "insert company role permission",
+        {},
+        Exception("composite foreign key changed concurrently"),
+    )
+    repository = RolePermissionRepository(session)
+    company_id = uuid4()
+    role = Role(id=uuid4(), name="Concurrent Role", description=None)
+    permission = Mock(id=uuid4())
+
+    monkeypatch.setattr(repository, "_ensure_company_role", lambda *args: Mock())
+    monkeypatch.setattr(repository, "_ensure_role", lambda role_id: role)
+    monkeypatch.setattr(
+        CompanyPermissionRepository,
+        "ensure_record",
+        lambda self, permission_id: permission,
+    )
+
+    with pytest.raises(AppError) as exc_info:
+        repository.assign_company_permission(
+            company_id,
+            role.id,
+            permission.id,
+        )
+
+    assert exc_info.value.status_code == 404
+    session.rollback.assert_called_once_with()

--- a/tests/database/test_superuser_bootstrap.py
+++ b/tests/database/test_superuser_bootstrap.py
@@ -1,0 +1,253 @@
+from uuid import uuid4
+
+import pytest
+
+from app.models.user.account_status import UserAccountStatus
+from app.repository.database.tables import (
+    PrivilegedAccessEvent,
+    SuperuserBootstrapControl,
+    User,
+)
+from app.services.superuser_bootstrap import (
+    SuperuserBootstrapError,
+    SuperuserBootstrapService,
+)
+
+
+def _add_control(test_session, **overrides) -> SuperuserBootstrapControl:
+    control = SuperuserBootstrapControl(
+        id=SuperuserBootstrapControl.SINGLETON_ID,
+        primary_meta_data={},
+        secondary_meta_data={},
+        **overrides,
+    )
+    test_session.add(control)
+    test_session.commit()
+    return control
+
+
+def _add_user(
+    test_session,
+    *,
+    label: str,
+    status: str = UserAccountStatus.ACTIVE.name_value,
+    is_superuser: bool = False,
+    refresh_token_version=0,
+) -> User:
+    user = User(
+        email=f"{label}-{uuid4().hex}@example.com",
+        password="unchanged-password-hash",
+        first_name=label,
+        is_superuser=is_superuser,
+        primary_meta_data={
+            "status": status,
+            "refresh_token_version": refresh_token_version,
+        },
+        secondary_meta_data={},
+    )
+    test_session.add(user)
+    test_session.commit()
+    return user
+
+
+def test_bootstrap_promotes_existing_active_user_and_is_idempotent(test_session):
+    control = _add_control(test_session)
+    user = _add_user(test_session, label="initial-admin", refresh_token_version=4)
+    service = SuperuserBootstrapService(test_session)
+
+    candidate = service.get_candidate(f"  {user.email.upper()}  ")
+    result = service.bootstrap(
+        email=user.email,
+        reason="  Initial production bootstrap  ",
+        expected_user_id=candidate.user_id,
+    )
+
+    test_session.refresh(user)
+    test_session.refresh(control)
+    assert result.user_id == user.id
+    assert result.changed is True
+    assert user.is_superuser is True
+    assert user.password == "unchanged-password-hash"
+    assert user.primary_meta_data["refresh_token_version"] == 5
+    assert control.bootstrap_user_id == user.id
+    assert control.bootstrap_completed_at is not None
+    assert control.bootstrap_method == service.SOURCE
+
+    event = test_session.query(PrivilegedAccessEvent).one()
+    assert event.actor_user_id is None
+    assert event.target_user_id == user.id
+    assert event.action == service.ACTION
+    assert event.source == service.SOURCE
+    assert event.reason == "Initial production bootstrap"
+    assert event.previous_superuser is False
+    assert event.resulting_superuser is True
+    assert event.request_id is None
+
+    repeated = service.bootstrap(
+        email=user.email,
+        reason="Safe retry",
+        expected_user_id=user.id,
+    )
+    test_session.refresh(user)
+    assert repeated.changed is False
+    assert user.primary_meta_data["refresh_token_version"] == 5
+    assert test_session.query(PrivilegedAccessEvent).count() == 1
+
+
+@pytest.mark.parametrize(
+    ("email", "expected_message"),
+    [
+        ("   ", "email is required"),
+        ("missing@example.com", "No active user exists"),
+    ],
+)
+def test_candidate_rejects_blank_or_missing_users(
+    test_session,
+    email,
+    expected_message,
+):
+    with pytest.raises(SuperuserBootstrapError, match=expected_message):
+        SuperuserBootstrapService(test_session).get_candidate(email)
+
+
+def test_candidate_rejects_deleted_and_inactive_users(test_session):
+    deleted = _add_user(test_session, label="deleted")
+    deleted._closed_at = deleted._created_at
+    test_session.commit()
+    inactive = _add_user(
+        test_session,
+        label="inactive",
+        status=UserAccountStatus.AWAITING_VERIFICATION.name_value,
+    )
+    service = SuperuserBootstrapService(test_session)
+
+    with pytest.raises(SuperuserBootstrapError, match="No active user exists"):
+        service.get_candidate(deleted.email)
+    with pytest.raises(SuperuserBootstrapError, match="active and verified"):
+        service.get_candidate(inactive.email)
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "x" * 1025])
+def test_bootstrap_rejects_invalid_reasons(test_session, reason):
+    with pytest.raises(SuperuserBootstrapError):
+        SuperuserBootstrapService(test_session).bootstrap(
+            email="unused@example.com",
+            reason=reason,
+            expected_user_id=uuid4(),
+        )
+
+
+def test_bootstrap_requires_migrated_singleton_control(test_session):
+    user = _add_user(test_session, label="no-control")
+
+    with pytest.raises(SuperuserBootstrapError, match="Apply Alembic migrations"):
+        SuperuserBootstrapService(test_session).bootstrap(
+            email=user.email,
+            reason="Initial bootstrap",
+            expected_user_id=user.id,
+        )
+    test_session.refresh(user)
+    assert user.is_superuser is False
+
+
+def test_bootstrap_rechecks_confirmed_identity_under_lock(test_session):
+    _add_control(test_session)
+    user = _add_user(test_session, label="mismatch")
+
+    with pytest.raises(SuperuserBootstrapError, match="confirmed user ID"):
+        SuperuserBootstrapService(test_session).bootstrap(
+            email=user.email,
+            reason="Initial bootstrap",
+            expected_user_id=uuid4(),
+        )
+
+
+def test_bootstrap_rejects_existing_superuser(test_session):
+    _add_control(test_session)
+    target = _add_user(test_session, label="target")
+    _add_user(test_session, label="existing-root", is_superuser=True)
+
+    with pytest.raises(SuperuserBootstrapError, match="already exists"):
+        SuperuserBootstrapService(test_session).bootstrap(
+            email=target.email,
+            reason="Initial bootstrap",
+            expected_user_id=target.id,
+        )
+    test_session.refresh(target)
+    assert target.is_superuser is False
+
+
+def test_completed_bootstrap_rejects_different_or_demoted_target(test_session):
+    original = _add_user(test_session, label="original", is_superuser=True)
+    other = _add_user(test_session, label="other")
+    control = _add_control(
+        test_session,
+        bootstrap_user_id=original.id,
+        bootstrap_completed_at=original._created_at,
+        bootstrap_method=SuperuserBootstrapService.SOURCE,
+    )
+    service = SuperuserBootstrapService(test_session)
+
+    with pytest.raises(SuperuserBootstrapError, match="already been completed"):
+        service.bootstrap(
+            email=other.email,
+            reason="Different target",
+            expected_user_id=other.id,
+        )
+
+    original.is_superuser = False
+    test_session.commit()
+    with pytest.raises(SuperuserBootstrapError, match="already been completed"):
+        service.bootstrap(
+            email=original.email,
+            reason="Do not restore silently",
+            expected_user_id=original.id,
+        )
+    test_session.refresh(control)
+    assert control.bootstrap_user_id == original.id
+
+
+def test_bootstrap_normalizes_invalid_refresh_token_version(test_session):
+    _add_control(test_session)
+    user = _add_user(
+        test_session,
+        label="invalid-version",
+        refresh_token_version="invalid",
+    )
+
+    SuperuserBootstrapService(test_session).bootstrap(
+        email=user.email,
+        reason="Initial bootstrap",
+        expected_user_id=user.id,
+    )
+
+    test_session.refresh(user)
+    assert user.primary_meta_data["refresh_token_version"] == 1
+
+
+def test_bootstrap_rolls_back_privilege_change_when_commit_fails(
+    test_session,
+    monkeypatch,
+):
+    _add_control(test_session)
+    user = _add_user(test_session, label="rollback")
+    monkeypatch.setattr(
+        test_session,
+        "commit",
+        lambda: (_ for _ in ()).throw(RuntimeError("audit transaction failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="audit transaction failed"):
+        SuperuserBootstrapService(test_session).bootstrap(
+            email=user.email,
+            reason="Initial bootstrap",
+            expected_user_id=user.id,
+        )
+
+    test_session.expire_all()
+    persisted = test_session.query(User).filter_by(id=user.id).one()
+    control = test_session.query(SuperuserBootstrapControl).one()
+    assert persisted.is_superuser is False
+    assert persisted.primary_meta_data["refresh_token_version"] == 0
+    assert control.bootstrap_completed_at is None
+    assert test_session.query(PrivilegedAccessEvent).count() == 0

--- a/tests/database/test_superuser_bootstrap_migration.py
+++ b/tests/database/test_superuser_bootstrap_migration.py
@@ -1,0 +1,64 @@
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import (
+    Column,
+    MetaData,
+    String,
+    Table,
+    Uuid,
+    create_engine,
+    inspect,
+    select,
+)
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "alembic/versions/d1e5f7a9b302_add_superuser_bootstrap_control.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(
+        "add_superuser_bootstrap_control_migration",
+        MIGRATION_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_superuser_bootstrap_migration_upgrade_and_downgrade():
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "user",
+        metadata,
+        Column("id", Uuid(), primary_key=True),
+        Column("email", String(255), nullable=False),
+    )
+    metadata.create_all(engine)
+    migration = _load_migration()
+
+    with engine.begin() as connection:
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+
+        inspector = inspect(connection)
+        assert "superuser_bootstrap_control" in inspector.get_table_names()
+        assert "privileged_access_event" in inspector.get_table_names()
+        control = Table(
+            "superuser_bootstrap_control",
+            MetaData(),
+            autoload_with=connection,
+        )
+        assert connection.execute(select(control.c.id)).scalar_one() == 1
+        assert {
+            index["name"] for index in inspector.get_indexes("privileged_access_event")
+        } == {"ix_privileged_access_event_target_created"}
+
+        migration.downgrade()
+        assert set(inspect(connection).get_table_names()) == {"user"}

--- a/tests/database/test_superuser_cli.py
+++ b/tests/database/test_superuser_cli.py
@@ -1,0 +1,215 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from click.testing import CliRunner
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.cli import admin
+from app.models.user.account_status import UserAccountStatus
+from app.repository.database import Base
+from app.repository.database.tables import (
+    PrivilegedAccessEvent,
+    SuperuserBootstrapControl,
+    User,
+)
+from app.services.superuser_bootstrap import SuperuserBootstrapError
+
+
+def _configure_cli_database(monkeypatch, tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'superuser-cli.db'}"
+    engine = create_engine(database_url)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    session = Session()
+    user = User(
+        email=f"cli-admin-{uuid4().hex}@example.com",
+        password="never-printed-password",
+        first_name="CLI",
+        is_superuser=False,
+        primary_meta_data={
+            "status": UserAccountStatus.ACTIVE.name_value,
+            "refresh_token_version": 0,
+        },
+        secondary_meta_data={},
+    )
+    session.add_all(
+        [
+            SuperuserBootstrapControl(
+                id=SuperuserBootstrapControl.SINGLETON_ID,
+                primary_meta_data={},
+                secondary_meta_data={},
+            ),
+            user,
+        ]
+    )
+    session.commit()
+    user_id = user.id
+    email = user.email
+    session.close()
+    engine.dispose()
+
+    class TestDatabaseManager:
+        def __init__(self):
+            self.engine = create_engine(database_url)
+            self.Session = sessionmaker(bind=self.engine, expire_on_commit=False)
+
+        def session_object(self):
+            return self.Session()
+
+    monkeypatch.setattr(admin, "DatabaseSessionManager", TestDatabaseManager)
+    return database_url, user_id, email
+
+
+def _read_state(database_url, user_id):
+    engine = create_engine(database_url)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        user = session.query(User).filter_by(id=user_id).one()
+        return (
+            user.is_superuser,
+            user.primary_meta_data["refresh_token_version"],
+            session.query(PrivilegedAccessEvent).count(),
+        )
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_cli_bootstraps_interactively_and_retries_with_exact_id(
+    monkeypatch,
+    tmp_path,
+):
+    database_url, user_id, email = _configure_cli_database(monkeypatch, tmp_path)
+    runner = CliRunner()
+
+    first = runner.invoke(
+        admin.cli,
+        [
+            "bootstrap-superuser",
+            "--email",
+            email,
+            "--reason",
+            "Initial production bootstrap",
+        ],
+        input="y\n",
+    )
+    assert first.exit_code == 0, first.output
+    assert str(user_id) in first.output
+    assert "completed" in first.output
+    assert "never-printed-password" not in first.output
+    assert _read_state(database_url, user_id) == (True, 1, 1)
+
+    repeated = runner.invoke(
+        admin.cli,
+        [
+            "bootstrap-superuser",
+            "--email",
+            email,
+            "--reason",
+            "Safe retry",
+            "--confirm-user-id",
+            str(user_id),
+        ],
+    )
+    assert repeated.exit_code == 0, repeated.output
+    assert "already complete" in repeated.output
+    assert _read_state(database_url, user_id) == (True, 1, 1)
+
+
+def test_cli_rejects_declined_or_mismatched_confirmation(monkeypatch, tmp_path):
+    database_url, user_id, email = _configure_cli_database(monkeypatch, tmp_path)
+    runner = CliRunner()
+
+    declined = runner.invoke(
+        admin.cli,
+        [
+            "bootstrap-superuser",
+            "--email",
+            email,
+            "--reason",
+            "Initial production bootstrap",
+        ],
+        input="n\n",
+    )
+    assert declined.exit_code == 1
+    assert "Aborted" in declined.output
+
+    mismatch = runner.invoke(
+        admin.cli,
+        [
+            "bootstrap-superuser",
+            "--email",
+            email,
+            "--reason",
+            "Initial production bootstrap",
+            "--confirm-user-id",
+            str(uuid4()),
+        ],
+    )
+    assert mismatch.exit_code == 1
+    assert "does not match" in mismatch.output
+    assert _read_state(database_url, user_id) == (False, 0, 0)
+
+
+def test_cli_reports_candidate_and_transaction_errors(monkeypatch):
+    disposed = []
+    manager = SimpleNamespace(
+        engine=SimpleNamespace(dispose=lambda: disposed.append(True)),
+    )
+    monkeypatch.setattr(admin, "DatabaseSessionManager", lambda: manager)
+    runner = CliRunner()
+    args = [
+        "bootstrap-superuser",
+        "--email",
+        "admin@example.com",
+        "--reason",
+        "Initial bootstrap",
+        "--confirm-user-id",
+        str(uuid4()),
+    ]
+
+    monkeypatch.setattr(
+        admin,
+        "_candidate",
+        lambda manager, email: (_ for _ in ()).throw(
+            SuperuserBootstrapError("candidate rejected")
+        ),
+    )
+    candidate_error = runner.invoke(admin.cli, args)
+    assert candidate_error.exit_code == 1
+    assert "candidate rejected" in candidate_error.output
+
+    user_id = uuid4()
+    monkeypatch.setattr(
+        admin,
+        "_candidate",
+        lambda manager, email: SimpleNamespace(
+            user_id=user_id,
+            email="admin@example.com",
+        ),
+    )
+    monkeypatch.setattr(
+        admin,
+        "_bootstrap",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            SuperuserBootstrapError("transaction rejected")
+        ),
+    )
+    transaction_error = runner.invoke(
+        admin.cli,
+        [*args[:-1], str(user_id)],
+    )
+    assert transaction_error.exit_code == 1
+    assert "transaction rejected" in transaction_error.output
+    assert disposed == [True, True]
+
+
+def test_admin_main_invokes_cli(monkeypatch):
+    invoked = []
+    monkeypatch.setattr(admin, "cli", lambda: invoked.append(True))
+
+    admin.main()
+
+    assert invoked == [True]

--- a/tests/database/test_system_permissions.py
+++ b/tests/database/test_system_permissions.py
@@ -1,0 +1,253 @@
+from uuid import uuid4
+
+import pytest
+
+from app.models.system_permissions import (
+    SYSTEM_PERMISSION_BY_ID,
+    SYSTEM_PERMISSION_DEFINITIONS,
+    SystemPermission,
+)
+from app.models.user.account_status import UserAccountStatus
+from app.models.user.user import UserReadModel
+from app.repository.company import CompanyRepository
+from app.repository.database.tables import (
+    AssociationUserCompany,
+    Company,
+    CompanyPermission,
+    CompanyRole,
+    CompanyRolePermission,
+    GlobalPermission,
+    Role,
+    RoleGlobalPermission,
+    User,
+    UserRole,
+)
+from app.repository.permission import SystemPermissionRepository
+from app.services.company.authorization import CompanyAuthorizationService
+from app.utils.app_error import AppError
+from app.utils.shared_context import SharedContext
+
+
+def _user_model(user: User, *, is_superuser: bool = False) -> UserReadModel:
+    return UserReadModel(
+        id=user.id,
+        email=user.email,
+        first_name=user.first_name,
+        status=UserAccountStatus.ACTIVE.name_value,
+        is_superuser=is_superuser,
+    )
+
+
+def _create_user(test_session, label: str) -> User:
+    user = User(
+        email=f"{label}-{uuid4().hex}@example.com",
+        password="secret",
+        first_name=label,
+        primary_meta_data={"status": UserAccountStatus.ACTIVE.name_value},
+    )
+    test_session.add(user)
+    test_session.flush()
+    return user
+
+
+def test_default_roles_receive_exact_system_permission_matrix(test_session):
+    repository = CompanyRepository(test_session)
+
+    roles = repository._ensure_default_roles()
+
+    permissions = test_session.query(GlobalPermission).all()
+    assert {permission.id for permission in permissions} == set(SYSTEM_PERMISSION_BY_ID)
+    assert all(permission.primary_meta_data["system"] for permission in permissions)
+
+    for role_name, role in roles.items():
+        actual_ids = {
+            permission_id
+            for (permission_id,) in test_session.query(
+                RoleGlobalPermission.global_permission_id
+            )
+            .filter(RoleGlobalPermission.role_id == role.id)
+            .all()
+        }
+        expected_ids = {
+            definition.id
+            for definition in SYSTEM_PERMISSION_DEFINITIONS
+            if role_name in definition.default_roles
+        }
+        assert actual_ids == expected_ids
+
+    removed = (
+        test_session.query(RoleGlobalPermission)
+        .filter_by(
+            role_id=roles["Owner"].id,
+            global_permission_id=SystemPermission.COMPANY_DELETE.permission_id,
+        )
+        .one()
+    )
+    test_session.delete(removed)
+    test_session.commit()
+
+    repository._ensure_default_roles()
+
+    assert (
+        test_session.query(RoleGlobalPermission)
+        .filter_by(
+            role_id=roles["Owner"].id,
+            global_permission_id=SystemPermission.COMPANY_DELETE.permission_id,
+        )
+        .one_or_none()
+        is None
+    )
+
+
+def test_system_permission_seeder_rejects_reserved_identity_conflicts(test_session):
+    conflicting = GlobalPermission(
+        name=SystemPermission.COMPANY_READ.value,
+        description="Conflicting tenant-created global permission",
+    )
+    test_session.add(conflicting)
+    test_session.commit()
+
+    with pytest.raises(AppError) as exc_info:
+        SystemPermissionRepository(test_session).ensure_permissions()
+
+    assert exc_info.value.status_code == 409
+
+
+def test_system_permission_definition_resolution_covers_exact_and_duplicate_records(
+    test_session,
+):
+    definition = SYSTEM_PERMISSION_DEFINITIONS[0]
+    exact = GlobalPermission(
+        id=definition.id,
+        name=definition.name,
+        description=definition.description,
+    )
+
+    assert SystemPermissionRepository._resolve_definition(definition, [exact]) is exact
+    with pytest.raises(AppError) as exc_info:
+        SystemPermissionRepository._resolve_definition(definition, [exact, exact])
+    assert exc_info.value.status_code == 409
+
+
+def test_company_authorization_uses_exact_global_permission_identity(test_session):
+    company = Company(
+        name="Authorization Company",
+        email=f"authorization-{uuid4().hex}@example.com",
+    )
+    test_session.add(company)
+    test_session.flush()
+    roles = CompanyRepository(test_session)._ensure_default_roles()
+    for role in roles.values():
+        test_session.add(CompanyRole(company_id=company.id, role_id=role.id))
+
+    users_by_role = {}
+    for role_name, role in roles.items():
+        user = _create_user(test_session, role_name.lower())
+        users_by_role[role_name] = user
+        test_session.add(
+            AssociationUserCompany(
+                user_id=user.id,
+                company_id=company.id,
+                role_id=role.id,
+            )
+        )
+    test_session.commit()
+
+    for role_name, user in users_by_role.items():
+        authorization = CompanyAuthorizationService(
+            SharedContext(db_session=test_session, user=_user_model(user))
+        )
+        expected_permissions = {
+            definition.permission
+            for definition in SYSTEM_PERMISSION_DEFINITIONS
+            if role_name in definition.default_roles
+        }
+        for permission in SystemPermission:
+            if permission in expected_permissions:
+                authorization.require(company.id, permission)
+            else:
+                with pytest.raises(AppError) as exc_info:
+                    authorization.require(company.id, permission)
+                assert exc_info.value.status_code == 403
+
+    viewer = users_by_role["Viewer"]
+    viewer_role = roles["Viewer"]
+    local_delete = CompanyPermission(
+        company_id=company.id,
+        name=SystemPermission.COMPANY_DELETE.value,
+        description="Same name, company scope",
+    )
+    test_session.add(local_delete)
+    test_session.flush()
+    test_session.add(
+        CompanyRolePermission(
+            company_id=company.id,
+            role_id=viewer_role.id,
+            company_permission_id=local_delete.id,
+        )
+    )
+    test_session.commit()
+
+    viewer_authorization = CompanyAuthorizationService(
+        SharedContext(db_session=test_session, user=_user_model(viewer))
+    )
+    with pytest.raises(AppError):
+        viewer_authorization.require(company.id, SystemPermission.COMPANY_DELETE)
+
+    outsider = _create_user(test_session, "platform-outsider")
+    test_session.add(UserRole(user_id=outsider.id, role_id=roles["Owner"].id))
+    test_session.commit()
+    outsider_authorization = CompanyAuthorizationService(
+        SharedContext(db_session=test_session, user=_user_model(outsider))
+    )
+    with pytest.raises(AppError):
+        outsider_authorization.require(company.id, SystemPermission.COMPANY_READ)
+
+    custom_role = Role(name=f"Custom Manager {uuid4().hex}", description=None)
+    custom_user = _create_user(test_session, "custom-manager")
+    test_session.add(custom_role)
+    test_session.flush()
+    test_session.add_all(
+        [
+            CompanyRole(company_id=company.id, role_id=custom_role.id),
+            RoleGlobalPermission(
+                role_id=custom_role.id,
+                global_permission_id=SystemPermission.COMPANY_UPDATE.permission_id,
+            ),
+            AssociationUserCompany(
+                user_id=custom_user.id,
+                company_id=company.id,
+                role_id=custom_role.id,
+            ),
+        ]
+    )
+    test_session.commit()
+    CompanyAuthorizationService(
+        SharedContext(db_session=test_session, user=_user_model(custom_user))
+    ).require(company.id, SystemPermission.COMPANY_UPDATE)
+
+    owner = users_by_role["Owner"]
+    owner_authorization = CompanyAuthorizationService(
+        SharedContext(db_session=test_session, user=_user_model(owner))
+    )
+    owner_authorization.require(company.id, SystemPermission.COMPANY_DELETE)
+    owner_delete_link = (
+        test_session.query(RoleGlobalPermission)
+        .filter_by(
+            role_id=roles["Owner"].id,
+            global_permission_id=SystemPermission.COMPANY_DELETE.permission_id,
+        )
+        .one()
+    )
+    test_session.delete(owner_delete_link)
+    test_session.commit()
+    with pytest.raises(AppError):
+        owner_authorization.require(company.id, SystemPermission.COMPANY_DELETE)
+
+    superuser = _create_user(test_session, "superuser")
+    CompanyAuthorizationService(
+        SharedContext(
+            db_session=test_session,
+            user=_user_model(superuser, is_superuser=True),
+        )
+    ).require(uuid4(), SystemPermission.COMPANY_DELETE)

--- a/tests/utils/test_lightweight_coverage.py
+++ b/tests/utils/test_lightweight_coverage.py
@@ -724,7 +724,7 @@ def test_company_user_service_sends_company_invite(monkeypatch):
     company = type("Company", (), {"name": "Acme Co"})()
 
     service = CompanyUserService(SharedContext(db_session=object(), user=acting_user))
-    monkeypatch.setattr(service, "check_if_user_is_in_company", lambda **kwargs: True)
+    monkeypatch.setattr(service.authorization, "require", lambda *args: None)
     monkeypatch.setattr(
         service.company_user_repository,
         "is_user_linked_to_company",
@@ -1332,11 +1332,7 @@ def test_company_service_branches_for_falsey_repository_results(monkeypatch):
         == CompanyResponseMessages.COMPANY_ID_OR_EMAIL_REQUIRED.value
     )
 
-    monkeypatch.setattr(
-        service.company_user_service.company_user_repository,
-        "is_user_linked_to_company",
-        lambda **kwargs: True,
-    )
+    monkeypatch.setattr(service.authorization, "require", lambda *args: None)
     monkeypatch.setattr(
         service.company_repository,
         "update_company",
@@ -1553,7 +1549,7 @@ def test_role_service_happy_path_branches(monkeypatch):
     role = RoleReadModel(id=str(role_id), name="Viewer", description="Read only")
 
     monkeypatch.setattr(service, "_ensure_superuser", lambda: None)
-    monkeypatch.setattr(service, "_ensure_company_manager", lambda cid: None)
+    monkeypatch.setattr(service, "_ensure_company_permission", lambda *args: None)
     monkeypatch.setattr(
         RoleRepository,
         "get_roles",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -538,6 +538,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -548,6 +549,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -558,6 +560,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1880,8 +1883,8 @@ wheels = [
 
 [[package]]
 name = "userverse"
-version = "0.6.36"
-source = { virtual = "." }
+version = "0.6.38"
+source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },


### PR DESCRIPTION
## Summary

This PR introduces a scalable hybrid RBAC system supporting global application permissions, company-scoped permissions, protected default API permissions, and secure offline bootstrapping of the first superuser.

## What changed

### Hybrid RBAC

- Added globally reusable application permissions.
- Added company-scoped permissions with tenant isolation.
- Global roles provide baseline permissions everywhere they are used.
- Companies can augment roles with their own permissions.
- Added direct platform role assignments for users.
- Platform roles do not grant company membership or tenant access.
- Role and membership responses now return structured permission objects with scope information.
- Added bulk permission loading to avoid N+1 queries.

### Permission management APIs

Added management endpoints for:

- Global permissions and role-permission assignments.
- Company permissions and company role-permission assignments.
- Direct platform role assignments.
- Authenticated user permission introspection.

Global permission and platform-role management remains superuser-only. Company permission management requires the appropriate company membership and authorization.

### Default API permissions

Added 16 deterministic, protected system permissions for existing company APIs.

Default assignments preserve the existing access model:

- Owner: full company administration, including deletion.
- Administrator: full administration except company deletion.
- Viewer: company and member read access.

Company-created permissions cannot authorize built-in Userverse management APIs. Core authorization checks use the seeded global permission UUIDs rather than permission names.

### Authorization enforcement

- Replaced company role-name authorization checks with permission checks.
- Superusers continue to bypass company membership and permission checks.
- Direct platform roles never authorize tenant access without company membership.
- Protected system permissions cannot be renamed or deleted.
- Superusers may update descriptions and manage their role assignments.
- Existing Owner safety protections remain in place.

### First-superuser bootstrap

Added a trusted offline command:

```bash
userverse-admin bootstrap-superuser \
  --email admin@example.com \
  --reason "Initial production bootstrap"
```

The command:

- Promotes an existing user and never creates accounts or accepts passwords.
- Requires the user to be active, verified, and not deleted.
- Uses a transactionally locked singleton bootstrap record.
- Rejects bootstrap when another superuser already exists.
- Requires interactive confirmation or an exact `--confirm-user-id`.
- Records an atomic privileged-access audit event.
- Increments `refresh_token_version` to invalidate existing sessions.
- Is idempotent only for the same successfully bootstrapped user.
- Never prints credentials, passwords, or tokens.

Future APIs for promoting and demoting additional superusers, step-up authentication, last-superuser protection, and break-glass administration are documented but intentionally not included in this PR.

## Database migrations

This PR adds three Alembic migrations:

1. Hybrid global and company-scoped permission tables and associations.
2. Deterministic protected system permissions and default role assignments.
3. First-superuser bootstrap control and privileged-access audit events.

Deployment requires:

```bash
uv run alembic upgrade head
```

The first administrator should then register and verify through the normal user flow before the offline bootstrap command is executed.

## Documentation

Added or updated documentation covering:

- Global and company roles and permissions.
- Default API permission matrix.
- Permission enforcement and tenant isolation.
- Secure first-superuser bootstrap operations.
- Future superuser administration APIs.
- Provider-neutral authorization roadmap.
- HTTP test data and testing guidance.

## Testing

```bash
uv run pytest -q \
  --cov=app \
  --cov-report=term-missing \
  --cov-fail-under=100
```

Results:

- 402 tests passed.
- 3,773 statements covered.
- 0 missed statements.
- 100% statement coverage.
- Migration upgrade and downgrade paths tested.
- Global/company tenant isolation tested.
- Default permissions tested across protected endpoints.
- Superuser bootstrap success, rejection, idempotency, confirmation, rollback, and audit behavior tested.

## Related tickets

- `#create-permission-model-company-scoped`
- `#link-roles-to-company-permissions`
- `#build-permission-management-functions`